### PR TITLE
Update dependency to fog-core ~> 1.22

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source "https://rubygems.org"
 
-gem "fog-core", :github => "fog/fog-core"
-
 gemspec

--- a/fog-brightbox.gemspec
+++ b/fog-brightbox.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "fog-core"
+  spec.add_dependency "fog-core", "~> 1.22"
   spec.add_dependency "fog-json"
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
The new Config functionality is now available in `fog-core` so we no
longer need to drag around a git reference.
