### PR TITLE
Add Brightbox model layer and specs

### DIFF
--- a/fog-brightbox.gemspec
+++ b/fog-brightbox.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "fog-core", "~> 1.22"
   spec.add_dependency "fog-json"
+  spec.add_dependency "inflecto"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/lib/fog/brightbox/model.rb
+++ b/lib/fog/brightbox/model.rb
@@ -1,0 +1,10 @@
+require "fog/core/model"
+require "fog/brightbox/model_helper"
+
+module Fog
+  module Brightbox
+    class Model < Fog::Model
+      include ModelHelper
+    end
+  end
+end

--- a/lib/fog/brightbox/model_helper.rb
+++ b/lib/fog/brightbox/model_helper.rb
@@ -1,0 +1,15 @@
+require "inflecto"
+
+module Fog
+  module Brightbox
+    module ModelHelper
+      def resource_name
+        Inflecto.underscore(Inflecto.demodulize(self.class))
+      end
+
+      def collection_name
+        Inflecto.pluralize(resource_name)
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/models/compute/account.rb
+++ b/lib/fog/brightbox/models/compute/account.rb
@@ -1,10 +1,9 @@
-require 'fog/core/model'
+require "fog/brightbox/model"
 
 module Fog
   module Compute
     class Brightbox
-
-      class Account < Fog::Model
+      class Account < Fog::Brightbox::Model
 
         identity :id
         attribute :url
@@ -61,9 +60,7 @@ module Fog
           merge_attributes(data)
           library_ftp_password
         end
-
       end
-
     end
   end
 end

--- a/lib/fog/brightbox/models/compute/api_client.rb
+++ b/lib/fog/brightbox/models/compute/api_client.rb
@@ -1,7 +1,9 @@
+require "fog/brightbox/model"
+
 module Fog
   module Compute
     class Brightbox
-      class ApiClient < Fog::Model
+      class ApiClient < Fog::Brightbox::Model
         identity :id
         attribute :name
         attribute :description

--- a/lib/fog/brightbox/models/compute/application.rb
+++ b/lib/fog/brightbox/models/compute/application.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require "fog/brightbox/model"
 
 module Fog
   module Compute
     class Brightbox
-      class Application < Fog::Model
+      class Application < Fog::Brightbox::Model
         identity :id
         attribute :url
         attribute :name

--- a/lib/fog/brightbox/models/compute/cloud_ip.rb
+++ b/lib/fog/brightbox/models/compute/cloud_ip.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require "fog/brightbox/model"
 
 module Fog
   module Compute
     class Brightbox
 
-      class CloudIp < Fog::Model
+      class CloudIp < Fog::Brightbox::Model
 
         identity :id
         attribute :url

--- a/lib/fog/brightbox/models/compute/collaboration.rb
+++ b/lib/fog/brightbox/models/compute/collaboration.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require "fog/brightbox/model"
 
 module Fog
   module Compute
     class Brightbox
-      class Collaboration < Fog::Model
+      class Collaboration < Fog::Brightbox::Model
         identity  :id
         attribute :status
         attribute :email

--- a/lib/fog/brightbox/models/compute/database_server.rb
+++ b/lib/fog/brightbox/models/compute/database_server.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require "fog/brightbox/model"
 
 module Fog
   module Compute
     class Brightbox
-      class DatabaseServer < Fog::Model
+      class DatabaseServer < Fog::Brightbox::Model
         identity :id
         attribute :url
         attribute :resource_type

--- a/lib/fog/brightbox/models/compute/database_snapshot.rb
+++ b/lib/fog/brightbox/models/compute/database_snapshot.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require "fog/brightbox/model"
 
 module Fog
   module Compute
     class Brightbox
-      class DatabaseSnapshot < Fog::Model
+      class DatabaseSnapshot < Fog::Brightbox::Model
         identity :id
         attribute :url
         attribute :resource_type

--- a/lib/fog/brightbox/models/compute/database_type.rb
+++ b/lib/fog/brightbox/models/compute/database_type.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require "fog/brightbox/model"
 
 module Fog
   module Compute
     class Brightbox
-      class DatabaseType < Fog::Model
+      class DatabaseType < Fog::Brightbox::Model
         identity :id
         attribute :url
         attribute :resource_type

--- a/lib/fog/brightbox/models/compute/event.rb
+++ b/lib/fog/brightbox/models/compute/event.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require "fog/brightbox/model"
 
 module Fog
   module Compute
     class Brightbox
 
-      class Event < Fog::Model
+      class Event < Fog::Brightbox::Model
 
         identity :id
         attribute :url

--- a/lib/fog/brightbox/models/compute/firewall_policy.rb
+++ b/lib/fog/brightbox/models/compute/firewall_policy.rb
@@ -1,10 +1,9 @@
-require 'fog/core/model'
+require "fog/brightbox/model"
 
 module Fog
   module Compute
     class Brightbox
-
-      class FirewallPolicy < Fog::Model
+      class FirewallPolicy < Fog::Brightbox::Model
 
         identity :id
         attribute :url

--- a/lib/fog/brightbox/models/compute/firewall_rule.rb
+++ b/lib/fog/brightbox/models/compute/firewall_rule.rb
@@ -1,10 +1,9 @@
-require 'fog/core/model'
+require "fog/brightbox/model"
 
 module Fog
   module Compute
     class Brightbox
-
-      class FirewallRule < Fog::Model
+      class FirewallRule < Fog::Brightbox::Model
 
         identity :id
         attribute :url
@@ -46,9 +45,7 @@ module Fog
           service.destroy_firewall_rule(identity)
           true
         end
-
       end
-
     end
   end
 end

--- a/lib/fog/brightbox/models/compute/flavor.rb
+++ b/lib/fog/brightbox/models/compute/flavor.rb
@@ -1,10 +1,9 @@
-require 'fog/core/model'
+require "fog/brightbox/model"
 
 module Fog
   module Compute
     class Brightbox
-
-      class Flavor < Fog::Model
+      class Flavor < Fog::Brightbox::Model
 
         identity :id
         attribute :url
@@ -24,9 +23,7 @@ module Fog
         def bits
           0 # This is actually based on the Image type used. 32bit or 64bit Images are supported
         end
-
       end
-
     end
   end
 end

--- a/lib/fog/brightbox/models/compute/image.rb
+++ b/lib/fog/brightbox/models/compute/image.rb
@@ -1,11 +1,9 @@
-require 'fog/core/model'
+require "fog/brightbox/model"
 
 module Fog
   module Compute
     class Brightbox
-
-      class Image < Fog::Model
-
+      class Image < Fog::Brightbox::Model
         identity :id
         attribute :url
         attribute :resource_type

--- a/lib/fog/brightbox/models/compute/load_balancer.rb
+++ b/lib/fog/brightbox/models/compute/load_balancer.rb
@@ -1,10 +1,9 @@
-require 'fog/core/model'
+require "fog/brightbox/model"
 
 module Fog
   module Compute
     class Brightbox
-
-      class LoadBalancer < Fog::Model
+      class LoadBalancer < Fog::Brightbox::Model
 
         identity :id
         attribute :url

--- a/lib/fog/brightbox/models/compute/server.rb
+++ b/lib/fog/brightbox/models/compute/server.rb
@@ -1,10 +1,11 @@
-require 'fog/compute/models/server'
+require "fog/compute/models/server"
+require "fog/brightbox/model_helper"
 
 module Fog
   module Compute
     class Brightbox
-
       class Server < Fog::Compute::Server
+        include Fog::Brightbox::ModelHelper
 
         identity  :id
         attribute :resource_type

--- a/lib/fog/brightbox/models/compute/server_group.rb
+++ b/lib/fog/brightbox/models/compute/server_group.rb
@@ -1,4 +1,4 @@
-require 'fog/core/model'
+require "fog/brightbox/model"
 
 module Fog
   module Compute
@@ -6,8 +6,7 @@ module Fog
       # A server group is a collection of servers
       #
       # Certain actions can accept a server group and affect all members
-      class ServerGroup < Fog::Model
-
+      class ServerGroup < Fog::Brightbox::Model
         identity :id
 
         attribute :url

--- a/lib/fog/brightbox/models/compute/user.rb
+++ b/lib/fog/brightbox/models/compute/user.rb
@@ -1,10 +1,9 @@
-require 'fog/core/model'
+require "fog/brightbox/model"
 
 module Fog
   module Compute
     class Brightbox
-
-      class User < Fog::Model
+      class User < Fog::Brightbox::Model
 
         identity :id
         attribute :resource_type
@@ -35,9 +34,7 @@ module Fog
           merge_attributes(data)
           true
         end
-
       end
-
     end
   end
 end

--- a/lib/fog/brightbox/models/compute/user_collaboration.rb
+++ b/lib/fog/brightbox/models/compute/user_collaboration.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require "fog/brightbox/model"
 
 module Fog
   module Compute
     class Brightbox
-      class UserCollaboration < Fog::Model
+      class UserCollaboration < Fog::Brightbox::Model
         identity  :id
         attribute :status
         attribute :email

--- a/lib/fog/brightbox/models/compute/zone.rb
+++ b/lib/fog/brightbox/models/compute/zone.rb
@@ -1,11 +1,9 @@
-require 'fog/core/model'
+require "fog/brightbox/model"
 
 module Fog
   module Compute
     class Brightbox
-
-      class Zone < Fog::Model
-
+      class Zone < Fog::Brightbox::Model
         identity :id
         attribute :url
         attribute :resource_type
@@ -14,9 +12,7 @@ module Fog
         attribute :handle
 
         attribute :description
-
       end
-
     end
   end
 end

--- a/spec/fog/compute/brightbox/account_spec.rb
+++ b/spec/fog/compute/brightbox/account_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/account"
+
+describe Fog::Compute::Brightbox::Account do
+  include ModelSetup
+
+  subject { service.accounts.new }
+
+  describe "when asked for collection name" do
+    it "responds 'accounts'" do
+      assert_equal "accounts", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'account'" do
+      assert_equal "account", subject.resource_name
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/api_client_spec.rb
+++ b/spec/fog/compute/brightbox/api_client_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/api_client"
+
+describe Fog::Compute::Brightbox::ApiClient do
+  include ModelSetup
+
+  subject { service.api_clients.new }
+
+  describe "when asked for collection name" do
+    it "responds 'api_clients'" do
+      assert_equal "api_clients", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'api_client'" do
+      assert_equal "api_client", subject.resource_name
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/application_spec.rb
+++ b/spec/fog/compute/brightbox/application_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/application"
+
+describe Fog::Compute::Brightbox::Application do
+  include ModelSetup
+
+  subject { service.applications.new }
+
+  describe "when asked for collection name" do
+    it "responds 'applications'" do
+      assert_equal "applications", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'application'" do
+      assert_equal "application", subject.resource_name
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/cloud_ip_spec.rb
+++ b/spec/fog/compute/brightbox/cloud_ip_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/cloud_ip"
+
+describe Fog::Compute::Brightbox::CloudIp do
+  include ModelSetup
+
+  subject { service.cloud_ips.new }
+
+  describe "when asked for collection name" do
+    it "responds 'cloud_ips'" do
+      assert_equal "cloud_ips", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'cloud_ip'" do
+      assert_equal "cloud_ip", subject.resource_name
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/collaboration_spec.rb
+++ b/spec/fog/compute/brightbox/collaboration_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/collaboration"
+
+describe Fog::Compute::Brightbox::Collaboration do
+  include ModelSetup
+
+  subject { service.collaborations.new }
+
+  describe "when asked for collection name" do
+    it "responds 'collaborations'" do
+      assert_equal "collaborations", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'collaboration'" do
+      assert_equal "collaboration", subject.resource_name
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/database_server_spec.rb
+++ b/spec/fog/compute/brightbox/database_server_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/database_server"
+
+describe Fog::Compute::Brightbox::DatabaseServer do
+  include ModelSetup
+
+  subject { service.database_servers.new }
+
+  describe "when asked for collection name" do
+    it "responds 'database_servers'" do
+      assert_equal "database_servers", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'database_server'" do
+      assert_equal "database_server", subject.resource_name
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/database_snapshot_spec.rb
+++ b/spec/fog/compute/brightbox/database_snapshot_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/database_snapshot"
+
+describe Fog::Compute::Brightbox::DatabaseSnapshot do
+  include ModelSetup
+
+  subject { service.database_snapshots.new }
+
+  describe "when asked for collection name" do
+    it "responds 'database_snapshots'" do
+      assert_equal "database_snapshots", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'database_snapshot'" do
+      assert_equal "database_snapshot", subject.resource_name
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/database_type_spec.rb
+++ b/spec/fog/compute/brightbox/database_type_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/database_type"
+
+describe Fog::Compute::Brightbox::DatabaseType do
+  include ModelSetup
+
+  subject { service.database_types.new }
+
+  describe "when asked for collection name" do
+    it "responds 'database_types'" do
+      assert_equal "database_types", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'database_type'" do
+      assert_equal "database_type", subject.resource_name
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/event_spec.rb
+++ b/spec/fog/compute/brightbox/event_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/event"
+
+describe Fog::Compute::Brightbox::Event do
+  include ModelSetup
+
+  subject { service.events.new }
+
+  describe "when asked for collection name" do
+    it "responds 'events'" do
+      assert_equal "events", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'event'" do
+      assert_equal "event", subject.resource_name
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/firewall_policy_spec.rb
+++ b/spec/fog/compute/brightbox/firewall_policy_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/firewall_policy"
+
+describe Fog::Compute::Brightbox::FirewallPolicy do
+  include ModelSetup
+
+  subject { service.firewall_policies.new }
+
+  describe "when asked for collection name" do
+    it "responds 'firewall_policies'" do
+      assert_equal "firewall_policies", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'firewall_policy'" do
+      assert_equal "firewall_policy", subject.resource_name
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/flavor_spec.rb
+++ b/spec/fog/compute/brightbox/flavor_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/flavor"
+
+describe Fog::Compute::Brightbox::Flavor do
+  include ModelSetup
+
+  subject { service.flavors.new }
+
+  describe "when asked for collection name" do
+    it "responds 'flavors'" do
+      assert_equal "flavors", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'flavor'" do
+      assert_equal "flavor", subject.resource_name
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/image_spec.rb
+++ b/spec/fog/compute/brightbox/image_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/image"
+
+describe Fog::Compute::Brightbox::Image do
+  include ModelSetup
+
+  subject { service.images.new }
+
+  describe "when asked for collection name" do
+    it "responds 'images'" do
+      assert_equal "images", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'image'" do
+      assert_equal "image", subject.resource_name
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/load_balancer_spec.rb
+++ b/spec/fog/compute/brightbox/load_balancer_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/load_balancer"
+
+describe Fog::Compute::Brightbox::LoadBalancer do
+  include ModelSetup
+
+  subject { service.load_balancers.new }
+
+  describe "when asked for collection name" do
+    it "responds 'load_balancers'" do
+      assert_equal "load_balancers", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'load_balancer'" do
+      assert_equal "load_balancer", subject.resource_name
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/server_group_spec.rb
+++ b/spec/fog/compute/brightbox/server_group_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/server_group"
+
+describe Fog::Compute::Brightbox::ServerGroup do
+  include ModelSetup
+
+  subject { service.server_groups.new }
+
+  describe "when asked for collection name" do
+    it "responds 'server_groups'" do
+      assert_equal "server_groups", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'server_group'" do
+      assert_equal "server_group", subject.resource_name
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/server_spec.rb
+++ b/spec/fog/compute/brightbox/server_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/server"
+
+describe Fog::Compute::Brightbox::Server do
+  include ModelSetup
+
+  subject { service.servers.new }
+
+  describe "when asked for collection name" do
+    it "responds 'servers'" do
+      assert_equal "servers", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'server'" do
+      assert_equal "server", subject.resource_name
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/user_collaboration_spec.rb
+++ b/spec/fog/compute/brightbox/user_collaboration_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/user_collaboration"
+
+describe Fog::Compute::Brightbox::UserCollaboration do
+  include ModelSetup
+
+  subject { service.user_collaborations.new }
+
+  describe "when asked for collection name" do
+    it "responds 'user_collaborations'" do
+      assert_equal "user_collaborations", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'user_collaboration'" do
+      assert_equal "user_collaboration", subject.resource_name
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/user_spec.rb
+++ b/spec/fog/compute/brightbox/user_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/user"
+
+describe Fog::Compute::Brightbox::User do
+  include ModelSetup
+
+  subject { service.users.new }
+
+  describe "when asked for collection name" do
+    it "responds 'users'" do
+      assert_equal "users", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'user'" do
+      assert_equal "user", subject.resource_name
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/zone_spec.rb
+++ b/spec/fog/compute/brightbox/zone_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/zone"
+
+describe Fog::Compute::Brightbox::Zone do
+  include ModelSetup
+
+  subject { service.zones.new }
+
+  describe "when asked for collection name" do
+    it "responds 'zones'" do
+      assert_equal "zones", subject.collection_name
+    end
+  end
+
+  describe "when asked for resource name" do
+    it "responds 'zone'" do
+      assert_equal "zone", subject.resource_name
+    end
+  end
+end

--- a/spec/model_helper.rb
+++ b/spec/model_helper.rb
@@ -1,0 +1,22 @@
+module ModelSetup
+  def self.included(base)
+    base.class_eval do
+      let(:configuration) do
+        {
+          :brightbox_auth_url => "http://localhost",
+          :brightbox_api_url => "http://localhost",
+          :brightbox_client_id => "",
+          :brightbox_secret => "",
+          :brightbox_username => "",
+          :brightbox_password => "",
+          :brightbox_account => "",
+          :brightbox_default_image => "img-test",
+          :brightbox_access_token => "FAKECACHEDTOKEN"
+        }
+      end
+
+      let(:config) { Fog::Brightbox::Config.new(configuration) }
+      let(:service) { Fog::Compute::Brightbox.new(config) }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,3 @@
 require "minitest/autorun"
 require "fog/brightbox"
+require "model_helper"


### PR DESCRIPTION
This adds a `Fog::Brightbox::Model` layer between most of the models and `Fog::Brightbox` and uses that to compose in shared functionality.

Initially this is some infection work supported by the `inflecto` gem.

Specs are also present for the models but due to the initializer hitting the service there is a lot of setup to make this work.
