### PR TITLE
Add support for Brightbox Orbit Cloud Storage

### DIFF
--- a/lib/fog/brightbox.rb
+++ b/lib/fog/brightbox.rb
@@ -1,1 +1,2 @@
 require 'fog/brightbox/compute'
+require 'fog/brightbox/storage'

--- a/lib/fog/brightbox/core.rb
+++ b/lib/fog/brightbox/core.rb
@@ -7,5 +7,6 @@ module Fog
     extend Fog::Provider
 
     service(:compute, 'Compute')
+    service(:storage, 'Storage')
   end
 end

--- a/lib/fog/brightbox/models/compute/api_client.rb
+++ b/lib/fog/brightbox/models/compute/api_client.rb
@@ -9,13 +9,15 @@ module Fog
         attribute :description
         attribute :secret
         attribute :revoked_at, :type => :time
+        attribute :permissions_group
         attribute :account_id
 
         def save
           raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           options = {
             :name => name,
-            :description => description
+            :description => description,
+            :permissions_group => permissions_group
           }.delete_if { |k, v| v.nil? || v == "" }
           data = service.create_api_client(options)
           merge_attributes(data)

--- a/lib/fog/brightbox/models/storage/directories.rb
+++ b/lib/fog/brightbox/models/storage/directories.rb
@@ -1,0 +1,45 @@
+require 'fog/core/collection'
+require 'fog/brightbox/models/storage/directory'
+
+module Fog
+  module Storage
+    class Brightbox
+
+      class Directories < Fog::Collection
+
+        model Fog::Storage::Brightbox::Directory
+
+        HEADER_ATTRIBUTES = [
+          'X-Container-Bytes-Used', 'X-Container-Object-Count', 'X-Container-Read',
+          'X-Container-Write'
+        ]
+
+        def all
+          data = service.get_containers.body
+          load(data)
+        end
+
+        def get(key, options = {})
+          data = service.get_container(key, options)
+          directory = new(:key => key)
+          for key, value in data.headers
+            if HEADER_ATTRIBUTES.include?(key)
+              directory.merge_attributes(key => value)
+            end
+          end
+          directory.files.merge_attributes(options)
+          directory.files.instance_variable_set(:@loaded, true)
+
+          data.body.each do |file|
+            directory.files << directory.files.new(file)
+          end
+          directory
+        rescue Fog::Storage::Brightbox::NotFound
+          nil
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/fog/brightbox/models/storage/directory.rb
+++ b/lib/fog/brightbox/models/storage/directory.rb
@@ -1,0 +1,53 @@
+require "fog/core/model"
+require "fog/brightbox/models/storage/files"
+
+module Fog
+  module Storage
+    class Brightbox
+      class Directory < Fog::Model
+        identity  :key, :aliases => "name"
+
+        attribute :bytes, :aliases => "X-Container-Bytes-Used"
+        attribute :count, :aliases => "X-Container-Object-Count"
+        attribute :read_permissions, :aliases => "X-Container-Read"
+        attribute :write_permissions, :aliases => "X-Container-Write"
+
+        def destroy
+          requires :key
+          service.delete_container(key)
+          true
+        rescue Excon::Errors::NotFound
+          false
+        end
+
+        def files
+          @files ||= begin
+            Fog::Storage::Brightbox::Files.new(
+              :directory    => self,
+              :service   => service
+            )
+          end
+        end
+
+        def public=(new_public)
+          @public = new_public
+        end
+
+        def public_url
+          #raise NotImplementedError
+          ""
+        end
+
+        def save
+          requires :key
+          options = {
+            'read_permissions' => read_permissions,
+            'write_permissions' => write_permissions
+          }
+          service.put_container(key, options)
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/models/storage/file.rb
+++ b/lib/fog/brightbox/models/storage/file.rb
@@ -1,0 +1,166 @@
+require 'fog/core/model'
+
+module Fog
+  module Storage
+    class Brightbox
+
+      class File < Fog::Model
+
+        identity  :key,             :aliases => 'name'
+
+        attribute :content_length,  :aliases => ['bytes', 'Content-Length'], :type => :integer
+        attribute :content_type,    :aliases => ['content_type', 'Content-Type']
+        attribute :content_disposition, :aliases => ['content_disposition', 'Content-Disposition']
+        attribute :etag,            :aliases => ['hash', 'Etag']
+        attribute :last_modified,   :aliases => ['last_modified', 'Last-Modified'], :type => :time
+        attribute :access_control_allow_origin, :aliases => ['Access-Control-Allow-Origin']
+        attribute :origin,          :aliases => ['Origin']
+
+        def body
+          attributes[:body] ||= if last_modified
+            collection.get(identity).body
+          else
+            ''
+          end
+        end
+
+        def body=(new_body)
+          attributes[:body] = new_body
+        end
+
+        def directory
+          @directory
+        end
+
+        def copy(target_directory_key, target_file_key, options={})
+          requires :directory, :key
+          options['Content-Type'] ||= content_type if content_type
+          options['Access-Control-Allow-Origin'] ||= access_control_allow_origin if access_control_allow_origin
+          options['Origin'] ||= origin if origin
+          service.copy_object(directory.key, key, target_directory_key, target_file_key, options)
+          target_directory = service.directories.new(:key => target_directory_key)
+          target_directory.files.get(target_file_key)
+        end
+
+        def destroy
+          requires :directory, :key
+          service.delete_object(directory.key, key)
+          true
+        end
+
+        def metadata
+          @metadata ||= headers_to_metadata
+        end
+
+        def owner=(new_owner)
+          if new_owner
+            attributes[:owner] = {
+              :display_name => new_owner['DisplayName'],
+              :id           => new_owner['ID']
+            }
+          end
+        end
+
+        def public=(new_public)
+          new_public
+        end
+
+        # Get a url for file.
+        #
+        #     required attributes: key
+        #
+        # @param expires [String] number of seconds (since 1970-01-01 00:00) before url expires
+        # @param options [Hash]
+        # @return [String] url
+        #
+        def url(expires, options = {})
+          requires :directory, :key
+          self.service.create_temp_url(directory.key, key, expires, "GET", options)
+        end
+
+        def public_url
+          requires :key
+          self.collection.get_url(self.key)
+        end
+
+
+        def save(options = {})
+          requires :body, :directory, :key
+          options['Content-Type'] = content_type if content_type
+          options['Content-Disposition'] = content_disposition if content_disposition
+          options['Access-Control-Allow-Origin'] = access_control_allow_origin if access_control_allow_origin
+          options['Origin'] = origin if origin
+          options.merge!(metadata_to_headers)
+
+          data = service.put_object(directory.key, key, body, options)
+          update_attributes_from(data)
+          refresh_metadata
+
+          self.content_length = Fog::Storage.get_body_size(body)
+          self.content_type ||= Fog::Storage.get_content_type(body)
+          true
+        end
+
+        private
+
+        def directory=(new_directory)
+          @directory = new_directory
+        end
+
+        def refresh_metadata
+          metadata.reject! {|k, v| v.nil? }
+        end
+
+        def headers_to_metadata
+          key_map = key_mapping
+          Hash[metadata_attributes.map {|k, v| [key_map[k], v] }]
+        end
+
+        def key_mapping
+          key_map = metadata_attributes
+          key_map.each_pair {|k, v| key_map[k] = header_to_key(k)}
+        end
+
+        def header_to_key(opt)
+          opt.gsub(metadata_prefix, '').split('-').map {|k| k[0, 1].downcase + k[1..-1]}.join('_').to_sym
+        end
+
+        def metadata_to_headers
+          header_map = header_mapping
+          Hash[metadata.map {|k, v| [header_map[k], v] }]
+        end
+
+        def header_mapping
+          header_map = metadata.dup
+          header_map.each_pair {|k, v| header_map[k] = key_to_header(k)}
+        end
+
+        def key_to_header(key)
+          metadata_prefix + key.to_s.split(/[-_]/).map(&:capitalize).join('-')
+        end
+
+        def metadata_attributes
+          if last_modified
+            headers = service.head_object(directory.key, self.key).headers
+            headers.reject! {|k, v| !metadata_attribute?(k)}
+          else
+            {}
+          end
+        end
+
+        def metadata_attribute?(key)
+          key.to_s =~ /^#{metadata_prefix}/
+        end
+
+        def metadata_prefix
+          "X-Object-Meta-"
+        end
+
+        def update_attributes_from(data)
+          merge_attributes(data.headers.reject {|key, value| ['Content-Length', 'Content-Type'].include?(key)})
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/brightbox/models/storage/files.rb
+++ b/lib/fog/brightbox/models/storage/files.rb
@@ -1,0 +1,104 @@
+require 'fog/core/collection'
+require 'fog/brightbox/models/storage/file'
+
+module Fog
+  module Storage
+    class Brightbox
+
+      class Files < Fog::Collection
+
+        attribute :directory
+        attribute :limit
+        attribute :marker
+        attribute :path
+        attribute :prefix
+
+        model Fog::Storage::Brightbox::File
+
+        def all(options = {})
+          requires :directory
+          options = {
+            'limit'   => limit,
+            'marker'  => marker,
+            'path'    => path,
+            'prefix'  => prefix
+          }.merge!(options)
+          merge_attributes(options)
+          parent = directory.collection.get(
+            directory.key,
+            options
+          )
+          if parent
+            load(parent.files.map {|file| file.attributes})
+          else
+            nil
+          end
+        end
+
+        alias :each_file_this_page :each
+        def each
+          if !block_given?
+            self
+          else
+            subset = dup.all
+
+            subset.each_file_this_page {|f| yield f}
+            while subset.length == (subset.limit || 10000)
+              subset = subset.all(:marker => subset.last.key)
+              subset.each_file_this_page {|f| yield f}
+            end
+
+            self
+          end
+        end
+
+        def get(key, &block)
+          requires :directory
+          data = service.get_object(directory.key, key, &block)
+          file_data = data.headers.merge({
+            :body => data.body,
+            :key  => key
+          })
+          new(file_data)
+        rescue Fog::Storage::Brightbox::NotFound
+          nil
+        end
+
+        def get_url(key)
+          requires :directory
+          if self.directory.public_url
+            "#{self.directory.public_url}/#{Fog::Storage::Brightbox.escape(key, '/')}"
+          end
+        end
+
+        def get_http_url(key, expires, options = {})
+          requires :directory
+          service.get_object_http_url(directory.key, key, expires, options)
+        end
+
+        def get_https_url(key, expires, options = {})
+          requires :directory
+          service.get_object_https_url(directory.key, key, expires, options)
+        end
+
+        def head(key, options = {})
+          requires :directory
+          data = service.head_object(directory.key, key)
+          file_data = data.headers.merge({
+            :key => key
+          })
+          new(file_data)
+        rescue Fog::Storage::Brightbox::NotFound
+          nil
+        end
+
+        def new(attributes = {})
+          requires :directory
+          super({ :directory => directory }.merge!(attributes))
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/fog/brightbox/oauth2.rb
+++ b/lib/fog/brightbox/oauth2.rb
@@ -3,164 +3,168 @@
 #
 # @see http://tools.ietf.org/html/draft-ietf-oauth-v2-10
 #
-module Fog::Brightbox::OAuth2
+module Fog
+  module Brightbox
+    module OAuth2
 
-  # This builds the simplest form of requesting an access token
-  # based on the arguments passed in
-  #
-  # @param [Fog::Core::Connection] connection
-  # @param [CredentialSet] credentials
-  #
-  # @return [Excon::Response]
-  def request_access_token(connection, credentials)
-    token_strategy = credentials.best_grant_strategy
-
-    header_content = "#{credentials.client_id}:#{credentials.client_secret}"
-    encoded_credentials = Base64.encode64(header_content).chomp
-
-    connection.request(
-      :path => "/token",
-      :expects  => 200,
-      :headers  => {
-        'Authorization' => "Basic #{encoded_credentials}",
-        'Content-Type' => 'application/json'
-      },
-      :method   => 'POST',
-      :body     => Fog::JSON.encode(token_strategy.authorization_body_data)
-    )
-  end
-
-  # Encapsulates credentials required to request access tokens from the
-  # Brightbox authorisation servers
-  #
-  # @todo Interface to update certain credentials (after password change)
-  #
-  class CredentialSet
-    attr_reader :client_id, :client_secret, :username, :password
-    attr_reader :access_token, :refresh_token, :expires_in
+    # This builds the simplest form of requesting an access token
+    # based on the arguments passed in
     #
-    # @param [String] client_id
-    # @param [String] client_secret
-    # @param [Hash] options
-    # @option options [String] :username
-    # @option options [String] :password
+    # @param [Fog::Core::Connection] connection
+    # @param [CredentialSet] credentials
     #
-    def initialize(client_id, client_secret, options = {})
-      @client_id     = client_id
-      @client_secret = client_secret
-      @username      = options[:username]
-      @password      = options[:password]
-      @access_token  = options[:access_token]
-      @refresh_token = options[:refresh_token]
-      @expires_in    = options[:expires_in]
+    # @return [Excon::Response]
+    def request_access_token(connection, credentials)
+      token_strategy = credentials.best_grant_strategy
+
+      header_content = "#{credentials.client_id}:#{credentials.client_secret}"
+      encoded_credentials = Base64.encode64(header_content).chomp
+
+      connection.request(
+        :path => "/token",
+        :expects  => 200,
+        :headers  => {
+          'Authorization' => "Basic #{encoded_credentials}",
+          'Content-Type' => 'application/json'
+        },
+        :method   => 'POST',
+        :body     => Fog::JSON.encode(token_strategy.authorization_body_data)
+      )
     end
 
-    # Returns true if user details are available
-    # @return [Boolean]
-    def user_details?
-      !!(@username && @password)
-    end
-
-    # Is an access token available for these credentials?
-    def access_token?
-      !!@access_token
-    end
-
-    # Is a refresh token available for these credentials?
-    def refresh_token?
-      !!@refresh_token
-    end
-
-    # Updates the credentials with newer tokens
-    def update_tokens(access_token, refresh_token = nil, expires_in = nil)
-      @access_token  = access_token
-      @refresh_token = refresh_token
-      @expires_in    = expires_in
-    end
-
-    # Based on available credentials returns the best strategy
+    # Encapsulates credentials required to request access tokens from the
+    # Brightbox authorisation servers
     #
-    # @todo Add a means to dictate which should or shouldn't be used
+    # @todo Interface to update certain credentials (after password change)
     #
-    def best_grant_strategy
-      if refresh_token?
-        RefreshTokenStrategy.new(self)
-      elsif user_details?
-        UserCredentialsStrategy.new(self)
-      else
-        ClientCredentialsStrategy.new(self)
+    class CredentialSet
+      attr_reader :client_id, :client_secret, :username, :password
+      attr_reader :access_token, :refresh_token, :expires_in
+      #
+      # @param [String] client_id
+      # @param [String] client_secret
+      # @param [Hash] options
+      # @option options [String] :username
+      # @option options [String] :password
+      #
+      def initialize(client_id, client_secret, options = {})
+        @client_id     = client_id
+        @client_secret = client_secret
+        @username      = options[:username]
+        @password      = options[:password]
+        @access_token  = options[:access_token]
+        @refresh_token = options[:refresh_token]
+        @expires_in    = options[:expires_in]
+      end
+
+      # Returns true if user details are available
+      # @return [Boolean]
+      def user_details?
+        !!(@username && @password)
+      end
+
+      # Is an access token available for these credentials?
+      def access_token?
+        !!@access_token
+      end
+
+      # Is a refresh token available for these credentials?
+      def refresh_token?
+        !!@refresh_token
+      end
+
+      # Updates the credentials with newer tokens
+      def update_tokens(access_token, refresh_token = nil, expires_in = nil)
+        @access_token  = access_token
+        @refresh_token = refresh_token
+        @expires_in    = expires_in
+      end
+
+      # Based on available credentials returns the best strategy
+      #
+      # @todo Add a means to dictate which should or shouldn't be used
+      #
+      def best_grant_strategy
+        if refresh_token?
+          RefreshTokenStrategy.new(self)
+        elsif user_details?
+          UserCredentialsStrategy.new(self)
+        else
+          ClientCredentialsStrategy.new(self)
+        end
       end
     end
-  end
 
-  # This strategy class is the basis for OAuth2 grant types
-  #
-  # @abstract Need to implement {#authorization_body_data} to return a
-  #   Hash matching the expected parameter form for the OAuth request
-  #
-  # @todo Strategies should be able to validate if credentials are suitable
-  #   so just client credentials cannot be used with user strategies
-  #
-  class GrantTypeStrategy
-    def initialize(credentials)
-      @credentials = credentials
+    # This strategy class is the basis for OAuth2 grant types
+    #
+    # @abstract Need to implement {#authorization_body_data} to return a
+    #   Hash matching the expected parameter form for the OAuth request
+    #
+    # @todo Strategies should be able to validate if credentials are suitable
+    #   so just client credentials cannot be used with user strategies
+    #
+    class GrantTypeStrategy
+      def initialize(credentials)
+        @credentials = credentials
+      end
+
+      def authorization_body_data
+        raise "Not implemented"
+      end
     end
 
-    def authorization_body_data
-      raise "Not implemented"
+    # This implements client based authentication/authorization
+    # based on the existing trust relationship using the `none`
+    # grant type.
+    #
+    class ClientCredentialsStrategy < GrantTypeStrategy
+      def authorization_body_data
+        {
+          "grant_type" => "none",
+          "client_id"  => @credentials.client_id
+        }
+      end
+    end
+
+    # This passes user details through so the returned token
+    # carries the privileges of the user not account limited
+    # by the client
+    #
+    class UserCredentialsStrategy < GrantTypeStrategy
+      def authorization_body_data
+        {
+          "grant_type" => "password",
+          "client_id"  => @credentials.client_id,
+          "username"   => @credentials.username,
+          "password"   => @credentials.password
+        }
+      end
+    end
+
+    # This strategy attempts to use a refresh_token gained during an earlier
+    # request to reuse the credentials given originally
+    #
+    class RefreshTokenStrategy < GrantTypeStrategy
+      def authorization_body_data
+        {
+          "grant_type"    => "refresh_token",
+          "client_id"     => @credentials.client_id,
+          "refresh_token" => @credentials.refresh_token
+        }
+      end
+    end
+
+    private
+
+    # This updates the current credentials if passed a valid response
+    #
+    # @param [CredentialSet] credentials Credentials to update
+    # @param [Excon::Response] response Response object to parse value from
+    #
+    def update_credentials_from_response(credentials, response)
+      response_data = Fog::JSON.decode(response.body)
+      credentials.update_tokens(response_data["access_token"], response_data["refresh_token"], response_data["expires_in"])
     end
   end
-
-  # This implements client based authentication/authorization
-  # based on the existing trust relationship using the `none`
-  # grant type.
-  #
-  class ClientCredentialsStrategy < GrantTypeStrategy
-    def authorization_body_data
-      {
-        "grant_type" => "none",
-        "client_id"  => @credentials.client_id
-      }
-    end
-  end
-
-  # This passes user details through so the returned token
-  # carries the privileges of the user not account limited
-  # by the client
-  #
-  class UserCredentialsStrategy < GrantTypeStrategy
-    def authorization_body_data
-      {
-        "grant_type" => "password",
-        "client_id"  => @credentials.client_id,
-        "username"   => @credentials.username,
-        "password"   => @credentials.password
-      }
-    end
-  end
-
-  # This strategy attempts to use a refresh_token gained during an earlier
-  # request to reuse the credentials given originally
-  #
-  class RefreshTokenStrategy < GrantTypeStrategy
-    def authorization_body_data
-      {
-        "grant_type"    => "refresh_token",
-        "client_id"     => @credentials.client_id,
-        "refresh_token" => @credentials.refresh_token
-      }
-    end
-  end
-
-  private
-
-  # This updates the current credentials if passed a valid response
-  #
-  # @param [CredentialSet] credentials Credentials to update
-  # @param [Excon::Response] response Response object to parse value from
-  #
-  def update_credentials_from_response(credentials, response)
-    response_data = Fog::JSON.decode(response.body)
-    credentials.update_tokens(response_data["access_token"], response_data["refresh_token"], response_data["expires_in"])
-  end
+end
 end

--- a/lib/fog/brightbox/requests/storage/copy_object.rb
+++ b/lib/fog/brightbox/requests/storage/copy_object.rb
@@ -1,0 +1,27 @@
+module Fog
+  module Storage
+    class Brightbox
+      class Real
+
+        # Copy object
+        #
+        # ==== Parameters
+        # * source_container_name<~String> - Name of source bucket
+        # * source_object_name<~String> - Name of source object
+        # * target_container_name<~String> - Name of bucket to create copy in
+        # * target_object_name<~String> - Name for new copy of object
+        # * options<~Hash> - Additional headers
+        def copy_object(source_container_name, source_object_name, target_container_name, target_object_name, options={})
+          headers = { 'X-Copy-From' => "/#{source_container_name}/#{source_object_name}" }.merge(options)
+          request({
+            :expects  => 201,
+            :headers  => headers,
+            :method   => 'PUT',
+            :path     => "#{Fog::Storage::Brightbox.escape(target_container_name)}/#{Fog::Storage::Brightbox.escape(target_object_name)}"
+          })
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/delete_container.rb
+++ b/lib/fog/brightbox/requests/storage/delete_container.rb
@@ -1,0 +1,22 @@
+module Fog
+  module Storage
+    class Brightbox
+      class Real
+
+        # Delete an existing container
+        #
+        # ==== Parameters
+        # * name<~String> - Name of container to delete
+        #
+        def delete_container(name)
+          request(
+            :expects  => 204,
+            :method   => 'DELETE',
+            :path     => Fog::Storage::Brightbox.escape(name)
+          )
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/delete_multiple_objects.rb
+++ b/lib/fog/brightbox/requests/storage/delete_multiple_objects.rb
@@ -1,0 +1,67 @@
+module Fog
+  module Storage
+    class Brightbox
+      class Real
+
+        # Deletes multiple objects or containers with a single request.
+        #
+        # To delete objects from a single container, +container+ may be provided
+        # and +object_names+ should be an Array of object names within the container.
+        #
+        # To delete objects from multiple containers or delete containers,
+        # +container+ should be +nil+ and all +object_names+ should be prefixed with a container name.
+        #
+        # Containers must be empty when deleted. +object_names+ are processed in the order given,
+        # so objects within a container should be listed first to empty the container.
+        #
+        # Up to 10,000 objects may be deleted in a single request.
+        # The server will respond with +200 OK+ for all requests.
+        # +response.body+ must be inspected for actual results.
+        #
+        # @example Delete objects from a container
+        #   object_names = ['object', 'another/object']
+        #   conn.delete_multiple_objects('my_container', object_names)
+        #
+        # @example Delete objects from multiple containers
+        #   object_names = ['container_a/object', 'container_b/object']
+        #   conn.delete_multiple_objects(nil, object_names)
+        #
+        # @example Delete a container and all it's objects
+        #   object_names = ['my_container/object_a', 'my_container/object_b', 'my_container']
+        #   conn.delete_multiple_objects(nil, object_names)
+        #
+        # @param container [String,nil] Name of container.
+        # @param object_names [Array<String>] Object names to be deleted.
+        # @param options [Hash] Additional request headers.
+        #
+        # @return [Excon::Response]
+        #   * body [Hash] - Results of the operation.
+        #     * "Number Not Found" [Integer] - Number of missing objects or containers.
+        #     * "Response Status" [String] - Response code for the subrequest of the last failed operation.
+        #     * "Errors" [Array<object_name, response_status>]
+        #       * object_name [String] - Object that generated an error when the delete was attempted.
+        #       * response_status [String] - Response status from the subrequest for object_name.
+        #     * "Number Deleted" [Integer] - Number of objects or containers deleted.
+        #     * "Response Body" [String] - Response body for "Response Status".
+        def delete_multiple_objects(container, object_names, options = {})
+          body = object_names.map do |name|
+            object_name = container ? "#{ container }/#{ name }" : name
+            URI.encode(object_name)
+          end.join("\n")
+
+          response = request({
+            :expects  => 200,
+            :method   => 'DELETE',
+            :headers  => options.merge('Content-Type' => 'text/plain',
+                                       'Accept' => 'application/json'),
+            :body     => body,
+            :query    => { 'bulk-delete' => true }
+          }, false)
+          response.body = Fog::JSON.decode(response.body)
+          response
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/delete_object.rb
+++ b/lib/fog/brightbox/requests/storage/delete_object.rb
@@ -1,0 +1,23 @@
+module Fog
+  module Storage
+    class Brightbox
+      class Real
+
+        # Delete an existing object
+        #
+        # ==== Parameters
+        # * container<~String> - Name of container to delete
+        # * object<~String> - Name of object to delete
+        #
+        def delete_object(container, object)
+          request(
+            :expects  => 204,
+            :method   => 'DELETE',
+            :path     => "#{Fog::Storage::Brightbox.escape(container)}/#{Fog::Storage::Brightbox.escape(object)}"
+          )
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/delete_static_large_object.rb
+++ b/lib/fog/brightbox/requests/storage/delete_static_large_object.rb
@@ -1,0 +1,43 @@
+module Fog
+  module Storage
+    class Brightbox
+      class Real
+
+        # Delete a static large object.
+        #
+        # Deletes the SLO manifest +object+ and all segments that it references.
+        # The server will respond with +200 OK+ for all requests.
+        # +response.body+ must be inspected for actual results.
+        #
+        # @param container [String] Name of container.
+        # @param object [String] Name of the SLO manifest object.
+        # @param options [Hash] Additional request headers.
+        #
+        # @return [Excon::Response]
+        #   * body [Hash] - Results of the operation.
+        #     * "Number Not Found" [Integer] - Number of missing segments.
+        #     * "Response Status" [String] - Response code for the subrequest of the last failed operation.
+        #     * "Errors" [Array<object_name, response_status>]
+        #       * object_name [String] - Object that generated an error when the delete was attempted.
+        #       * response_status [String] - Response status from the subrequest for object_name.
+        #     * "Number Deleted" [Integer] - Number of segments deleted.
+        #     * "Response Body" [String] - Response body for Response Status.
+        #
+        # @see http://docs.brightbox.org/api/brightbox-object-storage/1.0/content/static-large-objects.html
+        def delete_static_large_object(container, object, options = {})
+          response = request({
+            :expects  => 200,
+            :method   => 'DELETE',
+            :headers  => options.merge('Content-Type' => 'text/plain',
+                                       'Accept' => 'application/json'),
+            :path     => "#{Fog::Storage::Brightbox.escape(container)}/#{Fog::Storage::Brightbox.escape(object)}",
+            :query    => { 'multipart-manifest' => 'delete' }
+          }, false)
+          response.body = Fog::JSON.decode(response.body)
+          response
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/get_container.rb
+++ b/lib/fog/brightbox/requests/storage/get_container.rb
@@ -1,0 +1,44 @@
+module Fog
+  module Storage
+    class Brightbox
+      class Real
+
+        # Get details for container and total bytes stored
+        #
+        # ==== Parameters
+        # * container<~String> - Name of container to retrieve info for
+        # * options<~String>:
+        #   * 'limit'<~String> - Maximum number of objects to return
+        #   * 'marker'<~String> - Only return objects whose name is greater than marker
+        #   * 'prefix'<~String> - Limits results to those starting with prefix
+        #   * 'path'<~String> - Return objects nested in the pseudo path
+        #
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * headers<~Hash>:
+        #     * 'X-Account-Container-Count'<~String> - Count of containers
+        #     * 'X-Account-Bytes-Used'<~String> - Bytes used
+        #   * body<~Array>:
+        #     * 'bytes'<~Integer> - Number of bytes used by container
+        #     * 'count'<~Integer> - Number of items in container
+        #     * 'name'<~String> - Name of container
+        #     * item<~Hash>:
+        #       * 'bytes'<~String> - Size of object
+        #       * 'content_type'<~String> Content-Type of object
+        #       * 'hash'<~String> - Hash of object (etag?)
+        #       * 'last_modified'<~String> - Last modified timestamp
+        #       * 'name'<~String> - Name of object
+        def get_container(container, options = {})
+          options = options.reject {|key, value| value.nil?}
+          request(
+            :expects  => 200,
+            :method   => 'GET',
+            :path     => Fog::Storage::Brightbox.escape(container),
+            :query    => {'format' => 'json'}.merge!(options)
+          )
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/get_containers.rb
+++ b/lib/fog/brightbox/requests/storage/get_containers.rb
@@ -1,0 +1,33 @@
+module Fog
+  module Storage
+    class Brightbox
+      class Real
+
+        # List existing storage containers
+        #
+        # ==== Parameters
+        # * options<~Hash>:
+        #   * 'limit'<~Integer> - Upper limit to number of results returned
+        #   * 'marker'<~String> - Only return objects with name greater than this value
+        #
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~Array>:
+        #     * container<~Hash>:
+        #       * 'bytes'<~Integer>: - Number of bytes used by container
+        #       * 'count'<~Integer>: - Number of items in container
+        #       * 'name'<~String>: - Name of container
+        def get_containers(options = {})
+          options = options.reject {|key, value| value.nil?}
+          request(
+            :expects  => [200, 204],
+            :method   => 'GET',
+            :path     => '',
+            :query    => {'format' => 'json'}.merge!(options)
+          )
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/get_object.rb
+++ b/lib/fog/brightbox/requests/storage/get_object.rb
@@ -1,0 +1,29 @@
+module Fog
+  module Storage
+    class Brightbox
+      class Real
+
+        # Get details for object
+        #
+        # ==== Parameters
+        # * container<~String> - Name of container to look in
+        # * object<~String> - Name of object to look for
+        #
+        def get_object(container, object, &block)
+          params = {
+            :expects  => 200,
+            :method   => 'GET',
+            :path     => "#{Fog::Storage::Brightbox.escape(container)}/#{Fog::Storage::Brightbox.escape(object)}"
+          }
+
+          if block_given?
+            params[:response_block] = block
+          end
+
+          request(params, false)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/get_object_http_url.rb
+++ b/lib/fog/brightbox/requests/storage/get_object_http_url.rb
@@ -1,0 +1,21 @@
+module Fog
+  module Storage
+    class Brightbox
+      class Real
+        # Get an expiring object http url
+        #
+        # ==== Parameters
+        # * container<~String> - Name of container containing object
+        # * object<~String> - Name of object to get expiring url for
+        # * expires<~Time> - An expiry time for this url
+        #
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~String> - url for object
+        def get_object_http_url(container, object, expires, options = {})
+          create_temp_url(container, object, expires, "GET", options.merge(:scheme => "http"))
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/get_object_https_url.rb
+++ b/lib/fog/brightbox/requests/storage/get_object_https_url.rb
@@ -1,0 +1,85 @@
+module Fog
+  module Storage
+    class Brightbox
+
+      class Real
+
+        # Get an expiring object https url from Cloud Files
+        #
+        # ==== Parameters
+        # * container<~String> - Name of container containing object
+        # * object<~String> - Name of object to get expiring url for
+        # * expires<~Time> - An expiry time for this url
+        #
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~String> - url for object
+        def get_object_https_url(container, object, expires, options = {})
+          create_temp_url(container, object, expires, "GET", options.merge(:scheme => "https"))
+        end
+
+        # creates a temporary url
+        #
+        # ==== Parameters
+        # * container<~String> - Name of container containing object
+        # * object<~String> - Name of object to get expiring url for
+        # * expires<~Time> - An expiry time for this url
+        # * method<~String> - The method to use for accessing the object (GET, PUT, HEAD)
+        # * scheme<~String> - The scheme to use (http, https)
+        # * options<~Hash> - An optional options hash
+        #
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~String> - url for object
+        #
+        # ==== See Also
+        # http://docs.rackspace.com/files/api/v1/cf-devguide/content/Create_TempURL-d1a444.html
+        def create_temp_url(container, object, expires, method, options = {})
+          raise ArgumentError, "Insufficient parameters specified." unless (container && object && expires && method)
+          raise ArgumentError, "Storage must be instantiated with the :brightbox_temp_url_key option" if @brightbox_temp_url_key.nil?
+
+          scheme = options[:scheme] || @scheme
+
+          # POST not allowed
+          allowed_methods = %w{GET PUT HEAD}
+          unless allowed_methods.include?(method)
+            raise ArgumentError.new("Invalid method '#{method}' specified. Valid methods are: #{allowed_methods.join(', ')}")
+          end
+
+
+          expires        = expires.to_i
+          object_path_escaped   = "#{@path}/#{Fog::Storage::Brightbox.escape(container)}/#{Fog::Storage::Brightbox.escape(object,"/")}"
+          object_path_unescaped = "#{@path}/#{Fog::Storage::Brightbox.escape(container)}/#{object}"
+          string_to_sign = "#{method}\n#{expires}\n#{object_path_unescaped}"
+
+          hmac = Fog::HMAC.new('sha1', @brightbox_temp_url_key)
+          sig  = sig_to_hex(hmac.sign(string_to_sign))
+
+          temp_url_options = {
+            :scheme => scheme,
+            :host => @host,
+            :port => @port,
+            :path => object_path_escaped,
+            :query => URI.encode_www_form(
+              :temp_url_sig => sig,
+              :temp_url_expires => expires
+            )
+          }
+          URI::Generic.build(temp_url_options).to_s
+        end
+
+        private
+
+        def sig_to_hex(str)
+          str.unpack("C*").map { |c|
+            c.to_s(16)
+          }.map { |h|
+            h.size == 1 ? "0#{h}" : h
+          }.join
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/head_container.rb
+++ b/lib/fog/brightbox/requests/storage/head_container.rb
@@ -1,0 +1,28 @@
+module Fog
+  module Storage
+    class Brightbox
+      class Real
+
+        # List number of objects and total bytes stored
+        #
+        # ==== Parameters
+        # * container<~String> - Name of container to retrieve info for
+        #
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * headers<~Hash>:
+        #     * 'X-Container-Object-Count'<~String> - Count of containers
+        #     * 'X-Container-Bytes-Used'<~String>   - Bytes used
+        def head_container(container)
+          request(
+            :expects  => 204,
+            :method   => 'HEAD',
+            :path     => Fog::Storage::Brightbox.escape(container),
+            :query    => {'format' => 'json'}
+          )
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/head_containers.rb
+++ b/lib/fog/brightbox/requests/storage/head_containers.rb
@@ -1,0 +1,25 @@
+module Fog
+  module Storage
+    class Brightbox
+      class Real
+
+        # List number of containers and total bytes stored
+        #
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * headers<~Hash>:
+        #     * 'X-Account-Container-Count'<~String> - Count of containers
+        #     * 'X-Account-Bytes-Used'<~String> - Bytes used
+        def head_containers
+          request(
+            :expects  => 204,
+            :method   => 'HEAD',
+            :path     => '',
+            :query    => {'format' => 'json'}
+          )
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/head_object.rb
+++ b/lib/fog/brightbox/requests/storage/head_object.rb
@@ -1,0 +1,23 @@
+module Fog
+  module Storage
+    class Brightbox
+      class Real
+
+        # Get headers for object
+        #
+        # ==== Parameters
+        # * container<~String> - Name of container to look in
+        # * object<~String> - Name of object to look for
+        #
+        def head_object(container, object)
+          request({
+            :expects  => 200,
+            :method   => 'HEAD',
+            :path     => "#{Fog::Storage::Brightbox.escape(container)}/#{Fog::Storage::Brightbox.escape(object)}"
+          }, false)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/post_set_meta_temp_url_key.rb
+++ b/lib/fog/brightbox/requests/storage/post_set_meta_temp_url_key.rb
@@ -1,0 +1,37 @@
+module Fog
+  module Storage
+    class Brightbox
+
+      class Real
+
+        # Set the account wide Temp URL Key. This is a secret key that's
+        # used to generate signed expiring URLs.
+        #
+        # Once the key has been set with this request you should create new
+        # Storage objects with the :brightbox_temp_url_key option then use
+        # the get_object_https_url method to generate expiring URLs.
+        #
+        # *** CAUTION *** changing this secret key will invalidate any expiring
+        # URLS generated with old keys.
+        #
+        # ==== Parameters
+        # * key<~String> - The new Temp URL Key
+        #
+        # ==== Returns
+        # * response<~Excon::Response>
+        #
+        # ==== See Also
+        # http://docs.rackspace.com/files/api/v1/cf-devguide/content/Set_Account_Metadata-d1a4460.html
+        def post_set_meta_temp_url_key(key)
+          request(
+            :expects  => [201, 202, 204],
+            :method   => 'POST',
+            :headers  => {'X-Account-Meta-Temp-Url-Key' => key}
+          )
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/put_container.rb
+++ b/lib/fog/brightbox/requests/storage/put_container.rb
@@ -1,0 +1,27 @@
+module Fog
+  module Storage
+    class Brightbox
+      class Real
+
+        # Create a new container
+        #
+        # ==== Parameters
+        # * name<~String> - Name for container, should be < 256 bytes and must not contain '/'
+        #
+        def put_container(name, options = {})
+          headers = options[:headers] || {}
+          headers['X-Container-Read'] ||= options.delete(:read_permissions)
+          headers['X-Container-Write'] ||= options.delete(:write_permissions)
+
+          request(
+            :expects  => [201, 202],
+            :method   => 'PUT',
+            :path     => Fog::Storage::Brightbox.escape(name),
+            :headers  => headers
+          )
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/put_dynamic_obj_manifest.rb
+++ b/lib/fog/brightbox/requests/storage/put_dynamic_obj_manifest.rb
@@ -1,0 +1,43 @@
+module Fog
+  module Storage
+    class Brightbox
+      class Real
+
+        # Create a new dynamic large object manifest
+        #
+        # Creates an object with a +X-Object-Manifest+ header that specifies the common prefix ("<container>/<prefix>")
+        # for all uploaded segments. Retrieving the manifest object streams all segments matching this prefix.
+        # Segments must sort in the order they should be concatenated. Note that any future objects stored in the container
+        # along with the segments that match the prefix will be included when retrieving the manifest object.
+        #
+        # All segments must be stored in the same container, but may be in a different container than the manifest object.
+        # The default +X-Object-Manifest+ header is set to "+container+/+object+", but may be overridden in +options+
+        # to specify the prefix and/or the container where segments were stored.
+        # If overridden, names should be CGI escaped (excluding spaces) if needed (see {Fog::Storage::Brightbox.escape}).
+        #
+        # @param container [String] Name for container where +object+ will be stored. Should be < 256 bytes and must not contain '/'
+        # @param object [String] Name for manifest object.
+        # @param options [Hash] Config headers for +object+.
+        # @option options [String] 'X-Object-Manifest' ("container/object") "<container>/<prefix>" for segment objects.
+        #
+        # @raise [Fog::Storage::Brightbox::NotFound] HTTP 404
+        # @raise [Excon::Errors::BadRequest] HTTP 400
+        # @raise [Excon::Errors::Unauthorized] HTTP 401
+        # @raise [Excon::Errors::HTTPStatusError]
+        #
+        # @see http://docs.brightbox.org/api/brightbox-object-storage/1.0/content/dynamic-large-object-creation.html
+        def put_dynamic_obj_manifest(container, object, options = {})
+          path = "#{Fog::Storage::Brightbox.escape(container)}/#{Fog::Storage::Brightbox.escape(object)}"
+          headers = {'X-Object-Manifest' => path}.merge(options)
+          request(
+            :expects  => 201,
+            :headers  => headers,
+            :method   => 'PUT',
+            :path     => path
+          )
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/put_object.rb
+++ b/lib/fog/brightbox/requests/storage/put_object.rb
@@ -1,0 +1,42 @@
+module Fog
+  module Storage
+    class Brightbox
+      class Real
+
+        # Create a new object
+        #
+        # When passed a block, it will make a chunked request, calling
+        # the block for chunks until it returns an empty string.
+        # In this case the data parameter is ignored.
+        #
+        # ==== Parameters
+        # * container<~String> - Name for container, should be < 256 bytes and must not contain '/'
+        # * object<~String> - Name for object
+        # * data<~String|File> - data to upload
+        # * options<~Hash> - config headers for object. Defaults to {}.
+        # * block<~Proc> - chunker
+        #
+        def put_object(container, object, data, options = {}, &block)
+          if block_given?
+            params = { :request_block => block }
+            headers = options
+          else
+            data = Fog::Storage.parse_data(data)
+            headers = data[:headers].merge!(options)
+            params = { :body => data[:body] }
+          end
+
+          params.merge!(
+            :expects    => 201,
+            :idempotent => !params[:request_block],
+            :headers    => headers,
+            :method     => 'PUT',
+            :path       => "#{Fog::Storage::Brightbox.escape(container)}/#{Fog::Storage::Brightbox.escape(object)}"
+          )
+
+          request(params)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/put_object_manifest.rb
+++ b/lib/fog/brightbox/requests/storage/put_object_manifest.rb
@@ -1,0 +1,16 @@
+module Fog
+  module Storage
+    class Brightbox
+      class Real
+
+        # Create a new dynamic large object manifest
+        #
+        # This is an alias for {#put_dynamic_obj_manifest} for backward compatibility.
+        def put_object_manifest(container, object, options = {})
+          put_dynamic_obj_manifest(container, object, options)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/storage/put_static_obj_manifest.rb
+++ b/lib/fog/brightbox/requests/storage/put_static_obj_manifest.rb
@@ -1,0 +1,57 @@
+module Fog
+  module Storage
+    class Brightbox
+      class Real
+
+        # Create a new static large object manifest.
+        #
+        # A static large object is similar to a dynamic large object. Whereas a GET for a dynamic large object manifest
+        # will stream segments based on the manifest's +X-Object-Manifest+ object name prefix, a static large object
+        # manifest streams segments which are defined by the user within the manifest. Information about each segment is
+        # provided in +segments+ as an Array of Hash objects, ordered in the sequence which the segments should be streamed.
+        #
+        # When the SLO manifest is received, each segment's +etag+ and +size_bytes+ will be verified.
+        # The +etag+ for each segment is returned in the response to {#put_object}, but may also be calculated.
+        # e.g. +Digest::MD5.hexdigest(segment_data)+
+        #
+        # The maximum number of segments for a static large object is 1000, and all segments (except the last) must be
+        # at least 1 MiB in size. Unlike a dynamic large object, segments are not required to be in the same container.
+        #
+        # @example
+        #   segments = [
+        #     { :path => 'segments_container/first_segment',
+        #       :etag => 'md5 for first_segment',
+        #       :size_bytes => 'byte size of first_segment' },
+        #     { :path => 'segments_container/second_segment',
+        #       :etag => 'md5 for second_segment',
+        #       :size_bytes => 'byte size of second_segment' }
+        #   ]
+        #   put_static_obj_manifest('my_container', 'my_large_object', segments)
+        #
+        # @param container [String] Name for container where +object+ will be stored.
+        #     Should be < 256 bytes and must not contain '/'
+        # @param object [String] Name for manifest object.
+        # @param segments [Array<Hash>] Segment data for the object.
+        # @param options [Hash] Config headers for +object+.
+        #
+        # @raise [Fog::Storage::Brightbox::NotFound] HTTP 404
+        # @raise [Excon::Errors::BadRequest] HTTP 400
+        # @raise [Excon::Errors::Unauthorized] HTTP 401
+        # @raise [Excon::Errors::HTTPStatusError]
+        #
+        # @see http://docs.brightbox.org/api/brightbox-object-storage/1.0/content/static-large-objects.html
+        def put_static_obj_manifest(container, object, segments, options = {})
+          request(
+            :expects  => 201,
+            :method   => 'PUT',
+            :headers  => options,
+            :body     => Fog::JSON.encode(segments),
+            :path     => "#{Fog::Storage::Brightbox.escape(container)}/#{Fog::Storage::Brightbox.escape(object)}",
+            :query    => { 'multipart-manifest' => 'put' }
+          )
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/storage.rb
+++ b/lib/fog/brightbox/storage.rb
@@ -1,0 +1,166 @@
+require "fog/brightbox/core"
+require "fog/brightbox/storage/errors"
+require "fog/brightbox/storage/config"
+require "fog/brightbox/storage/authentication_request"
+require "fog/brightbox/storage/connection"
+
+module Fog
+  module Storage
+    class Brightbox < Fog::Service
+
+      requires   :brightbox_client_id,
+                 :brightbox_secret
+      recognizes :persistent, :brightbox_service_name,
+                 :brightbox_storage_url,
+                 :brightbox_service_type, :brightbox_tenant,
+                 :brightbox_region, :brightbox_temp_url_key
+
+      model_path "fog/brightbox/models/storage"
+      model       :directory
+      collection  :directories
+      model       :file
+      collection  :files
+
+      request_path "fog/brightbox/requests/storage"
+      request :copy_object
+      request :delete_container
+      request :delete_object
+      request :delete_multiple_objects
+      request :delete_static_large_object
+      request :get_container
+      request :get_containers
+      request :get_object
+      request :get_object_http_url
+      request :get_object_https_url
+      request :head_container
+      request :head_containers
+      request :head_object
+      request :post_set_meta_temp_url_key
+      request :put_container
+      request :put_dynamic_obj_manifest
+      request :put_object
+      request :put_object_manifest
+      request :put_static_obj_manifest
+
+      class Mock
+        def initialize(options={})
+        end
+      end
+
+      class Real
+        def initialize(config)
+          if config.respond_to?(:config_service?) && config.config_service?
+            @config = config
+          else
+            @config = Fog::Brightbox::Config.new(config)
+          end
+          @config = Fog::Brightbox::Storage::Config.new(@config)
+
+          @temp_url_key = @config.storage_temp_key
+        end
+
+        def needs_to_authenticate?
+          @config.must_authenticate?
+        end
+
+        def authentication_url
+          @auth_url ||= URI.parse(@config.storage_url.to_s)
+        end
+
+        def management_url
+          @config.storage_management_url
+        end
+
+        def reload
+          @connection.reset
+        end
+
+        def account
+          @config.account
+        end
+
+        def change_account(account)
+          @config.change_account(account)
+        end
+
+        def reset_account_name
+          @config.reset_account
+        end
+
+        def connection
+          @connection ||= Fog::Brightbox::Storage::Connection.new(@config)
+        end
+
+        def request(params, parse_json = true)
+          begin
+            authenticate if @config.must_authenticate?
+            connection.request(params, parse_json)
+          rescue Fog::Brightbox::Storage::AuthenticationRequired => error
+            if @config.managed_tokens?
+              @config.expire_tokens!
+              authenticate
+              retry
+            else # bad credentials
+              raise error
+            end
+          rescue Excon::Errors::HTTPStatusError => error
+            raise case error
+            when Excon::Errors::NotFound
+              Fog::Storage::Brightbox::NotFound.slurp(error)
+            else
+              error
+            end
+          end
+        end
+
+        def authenticate
+          if !management_url || needs_to_authenticate?
+            response = Fog::Brightbox::Storage::AuthenticationRequest.new(@config).authenticate
+            if response.nil?
+              return false
+            else
+              update_config_from_auth_response(response)
+            end
+          else
+            false
+          end
+        end
+
+        # @param [URI] uri A URI object to extract the account from
+        # @return [String] The account
+        def extract_account_from_url(url)
+          url.path.split("/")[2]
+        end
+
+        private
+
+        def update_config_from_auth_response(response)
+          @config.update_tokens(response.access_token)
+
+          # Only update the management URL if not set
+          return true if management_url && account
+
+          unless management_url
+            new_management_url = response.management_url
+            if new_management_url && new_management_url != management_url.to_s
+              @config.storage_management_url = URI.parse(new_management_url)
+            end
+          end
+
+          unless account
+            # Extract the account ID sent by the server
+            change_account(extract_account_from_url(@config.storage_management_url))
+          end
+          true
+        end
+      end
+
+      # CGI.escape, but without special treatment on spaces
+      def self.escape(str,extra_exclude_chars = "")
+        str.gsub(/([^a-zA-Z0-9_.-#{extra_exclude_chars}]+)/) do
+          "%" + $1.unpack("H2" * $1.bytesize).join("%").upcase
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/storage/authentication_request.rb
+++ b/lib/fog/brightbox/storage/authentication_request.rb
@@ -1,0 +1,52 @@
+module Fog
+  module Brightbox
+    module Storage
+      class AuthenticationRequest
+        attr_accessor :access_token, :management_url
+        attr_accessor :user, :tenant
+
+        def initialize(config)
+          @config = config
+        end
+
+        def authenticate
+          response = authentication_request
+
+          self.access_token = response.headers["X-Auth-Token"]
+          self.management_url = response.headers["X-Server-Management-Url"] || response.headers["X-Storage-Url"]
+          self
+        rescue Excon::Errors::Error
+          nil
+        end
+
+        private
+
+        def authentication_request
+          authentication_url = URI.parse(@config.storage_url.to_s)
+          connection = Fog::Core::Connection.new(authentication_url.to_s)
+          request_settings = {
+            :expects => [200, 204],
+            :headers => auth_headers,
+            :method => "GET",
+            :path => "v1"
+          }
+          connection.request(request_settings)
+        end
+
+        def auth_headers
+          if @config.user_credentials?
+            {
+              "X-Auth-User" => @config.username,
+              "X-Auth-Key" => @config.password
+            }
+          else
+            {
+              "X-Auth-User" => @config.client_id,
+              "X-Auth-Key" => @config.client_secret
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/storage/config.rb
+++ b/lib/fog/brightbox/storage/config.rb
@@ -1,0 +1,23 @@
+require "delegate"
+
+module Fog
+  module Brightbox
+    module Storage
+      class Config < SimpleDelegator
+        def initialize(config)
+          super
+          @config = config
+          raise ArgumentError unless required_args_available?
+        end
+
+        private
+
+        def required_args_available?
+          return false unless @config.client_id
+          return false unless @config.client_secret
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/storage/connection.rb
+++ b/lib/fog/brightbox/storage/connection.rb
@@ -1,0 +1,83 @@
+require "fog/core/connection"
+require "fog/brightbox/storage/errors"
+
+module Fog
+  module Brightbox
+    module Storage
+      class Connection < Fog::Core::Connection
+        def initialize(config)
+          @config = config
+
+          unless management_url
+            raise ManagementUrlUnknown
+          else
+            @connection = super(management_url.to_s, persistent?, connection_options)
+          end
+        end
+
+        def request(params, parse_json = true)
+          begin
+            raise ArgumentError if params.nil?
+            request_params = params.merge({
+              :headers => request_headers(params),
+              :path => path_in_params(params)
+            })
+            response = @connection.request(request_params)
+          rescue Excon::Errors::Unauthorized => error
+            raise AuthenticationRequired.slurp(error)
+          rescue Excon::Errors::NotFound => error
+            raise Fog::Storage::Brightbox::NotFound.slurp(error)
+          rescue Excon::Errors::HTTPStatusError => error
+            raise error
+          end
+
+          if !response.body.empty? && parse_json && response.get_header("Content-Type") =~ %r{application/json}
+            response.body = Fog::JSON.decode(response.body)
+          end
+          response
+        end
+
+        def management_url
+          @config.storage_management_url
+        end
+
+        def path_in_params(params)
+          if params.respond_to?(:key?) && params.key?(:path)
+            URI.join(@config.storage_management_url.to_s + "/", params[:path]).path
+          else
+            @config.storage_management_url.path
+          end
+        end
+
+        def request_headers(excon_params)
+          if excon_params.respond_to?(:key?) && excon_params.key?(:headers)
+            authenticated_headers.merge(excon_params[:headers])
+          else
+            authenticated_headers
+          end
+        end
+
+        def authenticated_headers
+          default_headers.merge({
+            "X-Auth-Token" => @config.latest_access_token
+          })
+        end
+
+        def default_headers
+          {
+            "Content-Type" => "application/json",
+            "Accept" => "application/json"
+          }
+        end
+
+        def persistent?
+          @config.connection_persistent?
+        end
+
+        def connection_options
+          @config.storage_connection_options
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/storage/errors.rb
+++ b/lib/fog/brightbox/storage/errors.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Brightbox
+    module Storage
+      class ManagementUrlUnknown < Fog::Errors::Error
+      end
+
+      class AuthenticationRequired < Fog::Errors::Error
+      end
+    end
+  end
+end

--- a/spec/fog/brightbox/config_spec.rb
+++ b/spec/fog/brightbox/config_spec.rb
@@ -97,6 +97,25 @@ describe Fog::Brightbox::Config do
     end
   end
 
+  describe "when account was passed but changed" do
+    it "returns the new account" do
+      @options = { :brightbox_account => "acc-12345" }
+      @config = Fog::Brightbox::Config.new(@options)
+      @config.change_account("acc-abcde")
+      assert_equal "acc-abcde", @config.account
+    end
+  end
+
+  describe "when account was passed, changed and reset" do
+    it "returns the original account" do
+      @options = { :brightbox_account => "acc-12345" }
+      @config = Fog::Brightbox::Config.new(@options)
+      @config.change_account("acc-abcde")
+      @config.reset_account
+      assert_equal "acc-12345", @config.account
+    end
+  end
+
   describe "when connection options are passed" do
     it "returns the settings" do
       @connection_settings = {
@@ -135,7 +154,7 @@ describe Fog::Brightbox::Config do
   end
 
   describe "when cached OAuth tokens were passed" do
-    it "returns the settings" do
+    before do
       @access_token = "1234567890abcdefghijklmnopqrstuvwxyz"
       @refresh_token = "1234567890abcdefghijklmnopqrstuvwxyz"
       @options = {
@@ -143,8 +162,26 @@ describe Fog::Brightbox::Config do
         :brightbox_refresh_token => @refresh_token
       }
       @config = Fog::Brightbox::Config.new(@options)
+    end
+
+    it "returns the access token" do
       assert_equal @access_token, @config.cached_access_token
+      assert_equal @access_token, @config.latest_access_token
+    end
+
+    it "returns the refresh token" do
       assert_equal @refresh_token, @config.cached_refresh_token
+      assert_equal @refresh_token, @config.latest_refresh_token
+    end
+
+    it "does not need to authenticate" do
+      refute @config.must_authenticate?
+    end
+
+    it "can expire the tokens" do
+      @config.expire_tokens!
+      assert_nil @config.latest_access_token
+      assert_nil @config.latest_refresh_token
     end
   end
 
@@ -175,6 +212,30 @@ describe Fog::Brightbox::Config do
     it "returns nil" do
       @config = Fog::Brightbox::Config.new
       assert_nil @config.default_image_id
+    end
+  end
+
+  describe "when username and password are given" do
+    it "user_credentials? returns true" do
+      @options = {
+        :brightbox_client_id => "app-12345",
+        :brightbox_secret => "12345",
+        :brightbox_username => "user@example.com",
+        :brightbox_password => "12345"
+      }
+      @config = Fog::Brightbox::Config.new(@options)
+      assert @config.user_credentials?
+    end
+  end
+
+  describe "when no username is given" do
+    it "user_credentials? returns false" do
+      @options = {
+        :brightbox_client_id => "cli-12345",
+        :brightbox_secret => "12345"
+      }
+      @config = Fog::Brightbox::Config.new(@options)
+      refute @config.user_credentials?
     end
   end
 end

--- a/spec/fog/brightbox/storage/authentication_request_spec.rb
+++ b/spec/fog/brightbox/storage/authentication_request_spec.rb
@@ -1,0 +1,77 @@
+require "minitest/autorun"
+require "webmock/minitest"
+require "fog/brightbox"
+
+describe Fog::Brightbox::Storage::AuthenticationRequest do
+  describe "when initialised with blank config" do
+    before do
+      stub_request(:get, "https://files.gb1.brightbox.com/v1").
+        with(:headers => {
+        "Host" => "files.gb1.brightbox.com:443",
+        "X-Auth-User" => "",
+        "X-Auth-Key" => ""
+      }).to_return(:status => 412, :body => "Bad URL", :headers => {})
+    end
+
+    it "fails" do
+      settings = {}
+      @config = Fog::Brightbox::Config.new(settings)
+      @request = Fog::Brightbox::Storage::AuthenticationRequest.new(@config)
+      refute @request.authenticate
+    end
+  end
+
+  describe "when initialised with API client details" do
+    before do
+      stub_request(:get, "https://files.gb1.brightbox.com/v1").
+        with(:headers => {
+          "Host" => "files.gb1.brightbox.com:443",
+          "X-Auth-User" => "cli-12345",
+          "X-Auth-Key" => "12345"
+      }).to_return(:status => 200, :body => "Authenticated", :headers => {
+        "X-Storage-Url" => "https://files.gb1.brightbox.com/v1/acc-12345",
+        "X-Storage-Token" => "abcdefghijklmnopqrstuvwxyz1234567890",
+        "X-Auth-Token" => "abcdefghijklmnopqrstuvwxyz1234567890",
+        "Content-Type" => "text/plain"
+      })
+    end
+
+    it "authenticates correctly" do
+      settings = {
+        :brightbox_client_id => "cli-12345",
+        :brightbox_secret => "12345"
+      }
+      @config = Fog::Brightbox::Config.new(settings)
+      @request = Fog::Brightbox::Storage::AuthenticationRequest.new(@config)
+      assert @request.authenticate
+    end
+  end
+
+  describe "when initialised with user details" do
+    before do
+      stub_request(:get, "https://files.gb1.brightbox.com/v1").
+        with(:headers => {
+          "Host" => "files.gb1.brightbox.com:443",
+          "X-Auth-User" => "user@example.com",
+          "X-Auth-Key" => "abcde"
+      }).to_return(:status => 200, :body => "Authenticated", :headers => {
+        "X-Storage-Url" => "https://files.gb1.brightbox.com/v1/acc-12345",
+        "X-Storage-Token" => "abcdefghijklmnopqrstuvwxyz1234567890",
+        "X-Auth-Token" => "abcdefghijklmnopqrstuvwxyz1234567890",
+        "Content-Type" => "text/plain"
+      })
+    end
+
+    it "authenticates correctly" do
+      settings = {
+        :brightbox_client_id => "app-12345",
+        :brightbox_secret => "12345",
+        :brightbox_username => "user@example.com",
+        :brightbox_password => "abcde"
+      }
+      @config = Fog::Brightbox::Config.new(settings)
+      @request = Fog::Brightbox::Storage::AuthenticationRequest.new(@config)
+      assert @request.authenticate
+    end
+  end
+end

--- a/spec/fog/brightbox/storage/config_spec.rb
+++ b/spec/fog/brightbox/storage/config_spec.rb
@@ -1,0 +1,40 @@
+require "minitest/autorun"
+require "fog/brightbox"
+
+describe Fog::Brightbox::Storage::Config do
+  describe "when required arguments are included" do
+    it "nothing is raised" do
+      settings = {
+        :brightbox_client_id => "cli-12345",
+        :brightbox_secret => "1234567890"
+      }
+      config = Fog::Brightbox::Config.new(settings)
+      Fog::Brightbox::Storage::Config.new(config)
+      pass
+    end
+  end
+
+  describe "when client_id is not in configuration" do
+    it "raises ArgumentError" do
+      settings = {
+        :brightbox_secret => "1234567890"
+      }
+      config = Fog::Brightbox::Config.new(settings)
+      assert_raises ArgumentError do
+        Fog::Brightbox::Storage::Config.new(config)
+      end
+    end
+  end
+
+  describe "when client_secret is not in configuration" do
+    it "raises ArgumentError" do
+      settings = {
+        :brightbox_client_id => "cli-12345"
+      }
+      config = Fog::Brightbox::Config.new(settings)
+      assert_raises ArgumentError do
+        Fog::Brightbox::Storage::Config.new(config)
+      end
+    end
+  end
+end

--- a/spec/fog/brightbox/storage/connection_errors_spec.rb
+++ b/spec/fog/brightbox/storage/connection_errors_spec.rb
@@ -1,0 +1,54 @@
+require "minitest/autorun"
+require "webmock/minitest"
+require "fog/brightbox"
+
+describe Fog::Brightbox::Storage::Connection do
+  let(:config) { Fog::Brightbox::Config.new(settings) }
+  let(:connection) { Fog::Brightbox::Storage::Connection.new(config) }
+  let(:params) do
+    { :path => "fnord", :expects => [200] }
+  end
+  let(:settings) do
+    {
+      :brightbox_client_id => "app-12345",
+      :brightbox_secret => "1234567890",
+      :brightbox_storage_management_url => "https://files.gb2.brightbox.com/v1/acc-12345"
+    }
+  end
+  let(:valid_auth_token) { "01234567890abcdefghijklmnopqrstuvwxyz" }
+
+  {
+    400 => Excon::Errors::BadRequest,
+    401 => Fog::Brightbox::Storage::AuthenticationRequired,
+    402 => Excon::Errors::PaymentRequired,
+    403 => Excon::Errors::Forbidden,
+    404 => Fog::Storage::Brightbox::NotFound,
+    405 => Excon::Errors::MethodNotAllowed,
+    406 => Excon::Errors::NotAcceptable,
+    407 => Excon::Errors::ProxyAuthenticationRequired,
+    408 => Excon::Errors::RequestTimeout,
+    409 => Excon::Errors::Conflict,
+    410 => Excon::Errors::Gone,
+    411 => Excon::Errors::LengthRequired,
+    412 => Excon::Errors::PreconditionFailed,
+    413 => Excon::Errors::RequestEntityTooLarge,
+    414 => Excon::Errors::RequestURITooLong,
+    415 => Excon::Errors::UnsupportedMediaType,
+    416 => Excon::Errors::RequestedRangeNotSatisfiable,
+    417 => Excon::Errors::ExpectationFailed,
+    422 => Excon::Errors::UnprocessableEntity,
+    500 => Excon::Errors::InternalServerError,
+    501 => Excon::Errors::NotImplemented,
+    502 => Excon::Errors::BadGateway,
+    503 => Excon::Errors::ServiceUnavailable,
+    504 => Excon::Errors::GatewayTimeout
+  }.each do |status, error|
+    describe "when request responds with #{status}" do
+      it "raises #{error}" do
+        stub_request(:get, "https://files.gb2.brightbox.com/v1/acc-12345/fnord").
+          to_return(:status => status)
+        assert_raises(error) { connection.request(params) }
+      end
+    end
+  end
+end

--- a/spec/fog/brightbox/storage/connection_spec.rb
+++ b/spec/fog/brightbox/storage/connection_spec.rb
@@ -1,0 +1,120 @@
+require "minitest/autorun"
+require "webmock/minitest"
+require "fog/brightbox"
+
+describe Fog::Brightbox::Storage::Connection do
+  let(:config) { Fog::Brightbox::Config.new(settings) }
+  let(:connection) { Fog::Brightbox::Storage::Connection.new(config) }
+  let(:params) do
+    { :path => "fnord", :expects => [200] }
+  end
+  let(:settings) do
+    {
+      :brightbox_client_id => "app-12345",
+      :brightbox_secret => "1234567890",
+      :brightbox_storage_management_url => "https://files.gb2.brightbox.com/v1/acc-12345"
+    }
+  end
+  let(:valid_auth_token) { "01234567890abcdefghijklmnopqrstuvwxyz" }
+
+  describe "when management URL is not available" do
+    let(:settings) do
+      {
+        :brightbox_client_id => "app-12345",
+        :brightbox_secret => "1234567890"
+      }
+    end
+
+    it "raises Fog::Brightbox::Storage::ManagementUrlUnknown" do
+      assert_raises(Fog::Brightbox::Storage::ManagementUrlUnknown) { connection.request(params) }
+    end
+  end
+
+  describe "when parameters are nil" do
+    let(:params) {}
+
+    it "raises ArgumentError" do
+      assert_raises(ArgumentError) { connection.request(params) }
+    end
+  end
+
+  describe "when parameters are empty" do
+    let(:params) { {} }
+
+    before do
+      stub_request(:get, "https://files.gb2.brightbox.com/v1/acc-12345").
+        with(:headers => {
+        "Accept" => "application/json",
+        "Content-Type" => "application/json",
+        "X-Auth-Token" => valid_auth_token
+      }).to_return(:status => 200, :body => "{}", :headers => {
+        "Content-Type" => "application/json"
+      })
+    end
+
+    it "completes successfully" do
+      config.stub :latest_access_token, valid_auth_token do
+        connection.request(params)
+        pass
+      end
+    end
+  end
+
+  describe "when request should succeed" do
+    before do
+      stub_request(:get, "https://files.gb2.brightbox.com/v1/acc-12345/fnord").
+        with(:headers => {
+        "Accept" => "application/json",
+        "Content-Type" => "application/json",
+        "X-Auth-Token" => valid_auth_token
+      }).to_return(:status => 200, :body => "{}", :headers => {
+        "Content-Type" => "application/json"
+      })
+    end
+
+    it "completes successfully" do
+      config.stub :latest_access_token, valid_auth_token do
+        connection.request(params)
+        pass
+      end
+    end
+  end
+
+  describe "when custom headers are passed" do
+    let(:params) do
+      { :headers => { "X-Test" => "present" }, :path => "fnord" }
+    end
+
+    it "completes successfully" do
+      stub_request(:get, "https://files.gb2.brightbox.com/v1/acc-12345/fnord").
+        with(:headers => { "X-Test" => "present" }).to_return(:status => 200)
+
+      connection.request(params)
+      pass
+    end
+  end
+
+  describe "when container is not found" do
+    it "raises Fog::Storage::Brightbox::NotFound" do
+      stub_request(:get, "https://files.gb2.brightbox.com/v1/acc-12345/fnord").
+        to_return(:status => 404,
+                  :body => "<html><h1>Not Found</h1><p>The resource could not be found.</p></html>",
+                  :headers => {
+                    "Content-Type" => "text/html"
+                  })
+      assert_raises(Fog::Storage::Brightbox::NotFound) { connection.request(params) }
+    end
+  end
+
+  describe "when request is not authenticated" do
+    it "raises Fog::Brightbox::Storage::AuthenticationRequired" do
+      stub_request(:get, "https://files.gb2.brightbox.com/v1/acc-12345/fnord").
+        to_return(:status => 401,
+                  :body => "Authentication required",
+                  :headers => {
+                    "Content-Type" => "text/plain"
+                  })
+      assert_raises(Fog::Brightbox::Storage::AuthenticationRequired) { connection.request(params) }
+    end
+  end
+end

--- a/spec/fog/storage/brightbox_spec.rb
+++ b/spec/fog/storage/brightbox_spec.rb
@@ -1,0 +1,290 @@
+require "minitest/autorun"
+require "webmock/minitest"
+require "fog/brightbox"
+
+describe Fog::Storage::Brightbox do
+  let(:valid_auth_response) do
+    {
+      :status => 200,
+      :body => "Authenticated",
+      :headers => {
+        "X-Storage-Url"=>"https://files.gb1.brightbox.com:443/v1/acc-12345",
+        "Content-Length"=>"13",
+        "X-Storage-Token"=>"c1236c8c34d668df497c06075d8a76a79c6fdd0d",
+        "Content-Type"=>"text/plain",
+        "X-Auth-Token"=>"c1236c8c34d668df497c06075d8a76a79c6fdd0d",
+        "X-Trans-Id"=>"txcb228b8b9bfe4d5184828-0053568313",
+        "Date"=>"Tue, 22 Apr 2014 14:56:20 GMT"
+      }
+    }
+  end
+  let(:config) { Fog::Brightbox::Config.new(settings) }
+  let(:service) { Fog::Storage::Brightbox.new(config) }
+
+  describe "when created without required arguments" do
+    it "raises an error" do
+      Fog.stub :credentials, {} do
+        assert_raises ArgumentError do
+          Fog::Storage::Brightbox.new({})
+        end
+      end
+    end
+  end
+
+  describe "when created with a Config object" do
+    let(:settings) do
+      {
+        :brightbox_client_id => "cli-12345",
+        :brightbox_secret => "1234567890"
+      }
+    end
+
+    it "does not error" do
+      service
+      pass
+    end
+  end
+
+  describe "when created with Config missing required settings" do
+    let(:settings) { {} }
+
+    it "raises ArgumentError" do
+      assert_raises ArgumentError do
+        Fog::Storage::Brightbox.new(config)
+      end
+    end
+  end
+
+  describe "when created with a viable config" do
+    let(:settings) do
+      {
+        :brightbox_client_id => "cli-12345",
+        :brightbox_secret => "fdkls"
+      }
+    end
+
+    before do
+      stub_request(:get, "https://files.gb1.brightbox.com/v1").to_return(valid_auth_response)
+    end
+
+    it "requires a call to authenticate" do
+      assert service.needs_to_authenticate?
+    end
+
+    it "requires a call to discover management_url" do
+      assert_nil service.management_url
+    end
+
+    it "can authenticate" do
+      service.authenticate
+      assert_equal "https://files.gb1.brightbox.com/v1/acc-12345", service.management_url.to_s
+    end
+  end
+
+  describe "when created with bad credentials" do
+    let(:settings) do
+      {
+        :brightbox_client_id => "cli-12345",
+        :brightbox_secret => "wrong"
+      }
+    end
+
+    it "fails to authenticate" do
+      response =  {
+        :body=>"Bad URL",
+        :headers=>
+        {"Content-Length"=>"7",
+         "Content-Type"=>"text/html; charset=UTF-8",
+         "X-Trans-Id"=>"txab03ff4864ff42989f4a1-0053568282",
+         "Date"=>"Tue, 22 Apr 2014 14:53:54 GMT"},
+         :status=>412
+      }
+      stub_request(:get, "https://files.gb1.brightbox.com/v1").to_return(response)
+
+      service.authenticate
+      assert_nil service.management_url
+    end
+  end
+
+  describe "when configured scoped to a specific account" do
+    let(:settings) do
+      {
+        :brightbox_client_id => "app-12345",
+        :brightbox_secret => "12345",
+        :brightbox_username => "user@example.com",
+        :brightbox_password => "abcde",
+        :brightbox_account => "acc-abcde"
+      }
+    end
+
+    before do
+      stub_request(:get, "https://files.gb1.brightbox.com/v1").to_return(valid_auth_response)
+    end
+
+    it "uses the configured account" do
+      assert service.authenticate
+      assert_equal "acc-abcde", service.account
+    end
+  end
+
+  describe "when account is not configured" do
+    let(:settings) do
+      {
+        :brightbox_client_id => "app-12345",
+        :brightbox_secret => "12345",
+        :brightbox_username => "user@example.com",
+        :brightbox_password => "abcde"
+      }
+    end
+
+    before do
+      stub_request(:get, "https://files.gb1.brightbox.com/v1").to_return(valid_auth_response)
+    end
+
+    it "extracts the account from the management URL" do
+      assert service.authenticate
+      assert_equal "acc-12345", service.account
+    end
+  end
+
+  describe "when configured with existing token" do
+    let(:settings) do
+      {
+        :brightbox_client_id => "app-12345",
+        :brightbox_secret => "12345",
+        :brightbox_access_token => "1234567890abcdefghijklmnopqrstuvwxyz",
+        :brightbox_refresh_token => "1234567890abcdefghijklmnopqrstuvwxyz"
+      }
+    end
+
+    it "does not need to authenticate" do
+      refute service.needs_to_authenticate?
+    end
+
+    it "requires a call to discover management_url" do
+      assert_nil service.management_url
+    end
+  end
+
+  describe "when configured with tokens and management_url" do
+    let(:settings) do
+       {
+        :brightbox_client_id => "app-12345",
+        :brightbox_secret => "12345",
+        :brightbox_access_token => "1234567890abcdefghijklmnopqrstuvwxyz",
+        :brightbox_refresh_token => "1234567890abcdefghijklmnopqrstuvwxyz",
+        :brightbox_storage_management_url => "https://files.gb2.brightbox.com/v1/acc-12345"
+      }
+    end
+
+    it "does not need to authenticate" do
+      refute service.needs_to_authenticate?
+    end
+
+    it "uses configured management_url" do
+      assert_equal "https://files.gb2.brightbox.com/v1/acc-12345", service.management_url.to_s
+    end
+
+    it "keeps setting after authentication" do
+      stub_request(:get, "https://files.gb1.brightbox.com/v1").to_return(valid_auth_response)
+      config.expire_tokens!
+      service.authenticate
+      assert_equal "https://files.gb2.brightbox.com/v1/acc-12345", service.management_url.to_s
+    end
+  end
+
+  describe "when configured with expired tokens" do
+    let(:settings) do
+       {
+        :brightbox_client_id => "app-12345",
+        :brightbox_secret => "12345",
+        :brightbox_access_token => "1234567890abcdefghijklmnopqrstuvwxyz",
+        :brightbox_refresh_token => "1234567890abcdefghijklmnopqrstuvwxyz",
+        :brightbox_storage_management_url => "https://files.gb2.brightbox.com/v1/acc-12345",
+        :brightbox_token_management => false
+      }
+    end
+
+    before do
+      # Ongoing request but tokens are expired
+      stub_request(:get, "https://files.gb2.brightbox.com/v1/acc-12345/fnord").
+        to_return(:status => 401,
+                  :body => "Authentication required",
+                  :headers => { "Content-Type" => "text/plain" })
+    end
+
+    let(:params) { { :expects => [200], :path => "fnord" } }
+
+    it "raises Fog::Brightbox::Storage::AuthenticationRequired" do
+      assert_raises(Fog::Brightbox::Storage::AuthenticationRequired) { service.request(params) }
+    end
+  end
+
+  describe "when configured with user details and expired tokens" do
+    let(:settings) do
+       {
+        :brightbox_client_id => "app-12345",
+        :brightbox_secret => "12345",
+        :brightbox_username => "user@example.com",
+        :brightbox_password => "12345",
+        :brightbox_access_token => "1234567890abcdefghijklmnopqrstuvwxyz",
+        :brightbox_refresh_token => "1234567890abcdefghijklmnopqrstuvwxyz",
+        :brightbox_storage_url => "https://files.gb2.brightbox.com",
+        :brightbox_storage_management_url => "https://files.gb2.brightbox.com/v1/acc-12345"
+      }
+    end
+
+    before do
+      # Ongoing request but tokens are expired
+      stub_request(:get, "https://files.gb2.brightbox.com/v1/acc-12345/fnord").
+        with(:headers => { "X-Auth-Token" => "1234567890abcdefghijklmnopqrstuvwxyz" }).
+        to_return(:status => 401,
+                  :body => "Authentication required",
+                  :headers => { "Content-Type" => "text/plain" })
+
+      # The reauthentication
+      stub_request(:get, "https://files.gb2.brightbox.com/v1").
+        with(:headers => { "X-Auth-User" => "user@example.com", "X-Auth-Key" => "12345" }).
+        to_return(valid_auth_response)
+
+      # Repeated request
+      stub_request(:get, "https://files.gb2.brightbox.com/v1/acc-12345/fnord").
+        with(:headers => { "X-Auth-Token" => "c1236c8c34d668df497c06075d8a76a79c6fdd0d" }).
+        to_return(:status => 200)
+    end
+
+    let(:params) { { :expects => [200], :path => "fnord" } }
+
+    it "authenticates again and retries" do
+      service.request(params)
+      pass
+    end
+  end
+
+  describe "when configured with client credentials" do
+    let(:settings) do
+      {
+        :brightbox_client_id => "cli-12345",
+        :brightbox_secret => "12345"
+      }
+    end
+
+    before do
+      # Initial authentication
+      stub_request(:get, "https://files.gb1.brightbox.com/v1").
+        with(:headers => {"X-Auth-Key" => "12345", "X-Auth-User" => "cli-12345"}).
+        to_return(valid_auth_response)
+
+      stub_request(:get, "https://files.gb1.brightbox.com/v1/acc-12345/fnord").
+        with(:headers => { "X-Auth-Token" => "c1236c8c34d668df497c06075d8a76a79c6fdd0d" }).
+        to_return(:status => 200)
+    end
+
+    let(:params) { { :expects => [200], :path => "fnord" } }
+
+    it "authenticates again and retries" do
+      service.request(params)
+      pass
+    end
+  end
+end


### PR DESCRIPTION
This adds beta support for Orbit, Brightbox's cloud storage service
based on OpenStack Swift.

The majority of the code here is extracted from the existing
OpenStack storage provider rather than awaiting a stable common provider
that is being worked upon.

A number of tests will be merged upstream into `fog` since the shared
tests are in Shindo unlike this projects.
