### PR TITLE
Be pessimistic about `inflecto` gem version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ and its modules:
 * http://fog.io/
 * http://rubydoc.info/gems/fog/
 
+### Ruby 1.8.7
+
+If you are still using Ruby 1.8.7 in production, see `gemfiles/Gemfile.1.8.7`
+for a gemfile of 1.8.7 compatible version of dependencies you may need to
+specify in your application's `Gemfile`
+
 ## Contributing
 
 `fog` modules are kept within the main repo.

--- a/fog-brightbox.gemspec
+++ b/fog-brightbox.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "fog-core", "~> 1.22"
   spec.add_dependency "fog-json"
-  spec.add_dependency "inflecto"
+  spec.add_dependency "inflecto", "~> 0.0.2"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "minitest"

--- a/gemfiles/Gemfile.1.8.7
+++ b/gemfiles/Gemfile.1.8.7
@@ -2,5 +2,6 @@ source "https://rubygems.org"
 
 gem "fog-core", :github => "fog/fog-core"
 gem "mime-types", "~> 1.22"
+gem "inflecto", "~> 0.0.2"
 
 gemspec :path => ".."


### PR DESCRIPTION
Ruby 1.8 support is planned to be dropped so this add pessimistic
contraints to the last version supporting 1.8

See https://github.com/mbj/inflecto/pull/7
