### PR TITLE
Handle requests without paths causing issues

### DIFF
--- a/lib/fog/brightbox/storage/connection.rb
+++ b/lib/fog/brightbox/storage/connection.rb
@@ -44,8 +44,10 @@ module Fog
         def path_in_params(params)
           if params.respond_to?(:key?) && params.key?(:path)
             URI.join(@config.storage_management_url.to_s + "/", params[:path]).path
-          else
+          elsif @config.storage_management_url.respond_to?(:path)
             @config.storage_management_url.path
+          else
+            URI.parse(@config.storage_management_url).path
           end
         end
 


### PR DESCRIPTION
This is a patch to work around certain requests that appear to skip
declaring the `path` in their request (so addressing the main root with
metadata).

These triggered an alternative code branch where a `String` was being
inspected for a `URI#path` causing an issue.
