### PR TITLE
Ensure we check for `URI` in management URI

### DIFF
--- a/lib/fog/brightbox.rb
+++ b/lib/fog/brightbox.rb
@@ -1,2 +1,11 @@
+# See the main fog gem for more details about the top level class {Fog}
+#
+# @see https://github.com/fog/fo://github.com/fog/fog
+# @see http://fog.io/
+# @see http://rubydoc.info/gems/fog
+#
+module Fog
+end
+
 require "fog/brightbox/compute"
 require "fog/brightbox/storage"

--- a/lib/fog/brightbox/config.rb
+++ b/lib/fog/brightbox/config.rb
@@ -9,8 +9,6 @@ module Fog
     # is told a token has expired then another will not retry it.
     #
     class Config
-      attr_writer :storage_management_url
-
       # Creates a new set of configuration settings based on the options provided.
       #
       # @param [Hash] options The configuration settings
@@ -94,12 +92,25 @@ module Fog
         URI.parse(@options[:brightbox_storage_url] || "https://orbit.brightbox.com")
       end
 
+      # The {#storage_management_url} is based on the {#storage_url} and the account details used when
+      # autheticating. This is normally automatically discovered within the servive but can be
+      # overridden in the {Config}
+      #
+      # @return [URI] if the URL is configured
+      # @return [nil] if the URL is not configured
       def storage_management_url
         @storage_management_url ||= if @options.key?(:brightbox_storage_management_url)
                                       URI.parse(@options[:brightbox_storage_management_url])
                                     else
                                       nil
                                     end
+      end
+
+      # @param [URI] management_url The +URI+ to use for management requests.
+      # @raise [ArgumentError] if non +URI+ object passed
+      def storage_management_url=(management_url)
+        raise ArgumentError unless management_url.kind_of?(URI)
+        @storage_management_url = management_url
       end
 
       # @return [String] The configured identifier of the API client or user application.

--- a/lib/fog/brightbox/oauth2.rb
+++ b/lib/fog/brightbox/oauth2.rb
@@ -1,10 +1,10 @@
-# This module covers Brightbox's partial implementation of OAuth 2.0
-# and enables fog clients to implement several authentictication strategies
-#
-# @see http://tools.ietf.org/html/draft-ietf-oauth-v2-10
-#
 module Fog
   module Brightbox
+    # This module covers Brightbox's partial implementation of OAuth 2.0
+    # and enables fog clients to implement several authentictication strategies
+    #
+    # @see http://tools.ietf.org/html/draft-ietf-oauth-v2-10
+    #
     module OAuth2
       # This builds the simplest form of requesting an access token
       # based on the arguments passed in

--- a/spec/fog/brightbox/config_spec.rb
+++ b/spec/fog/brightbox/config_spec.rb
@@ -238,4 +238,20 @@ describe Fog::Brightbox::Config do
       refute @config.user_credentials?
     end
   end
+
+  describe "when setting management_url with URI" do
+    it "sets it correctly" do
+      uri = URI.parse("https://example.com")
+      @config = Fog::Brightbox::Config.new
+      @config.storage_management_url = uri
+      assert_equal @config.storage_management_url, uri
+    end
+  end
+
+  describe "when setting management_url with String" do
+    it "raises ArgumentError" do
+      uri = "http://example.com/wrong"
+      assert_raises(ArgumentError) { Fog::Brightbox::Config.new.storage_management_url = uri }
+    end
+  end
 end


### PR DESCRIPTION
Had an issue where the documentation had been removed and a client set
`storage_management_url` as a `String` which failed to respondto `#path`

This adds the documentation back to specify the contract expected and
now we raise if an invalid object is passed.
