### PR TITLE
Fix specs

### DIFF
--- a/lib/fog/brightbox/models/compute/server.rb
+++ b/lib/fog/brightbox/models/compute/server.rb
@@ -1,5 +1,6 @@
 require "fog/compute/models/server"
 require "fog/brightbox/compute/resource_locking"
+require "fog/brightbox/model_helper"
 
 module Fog
   module Compute

--- a/spec/fog/brightbox/storage/authentication_request_spec.rb
+++ b/spec/fog/brightbox/storage/authentication_request_spec.rb
@@ -1,6 +1,4 @@
-require "minitest/autorun"
-require "webmock/minitest"
-require "fog/brightbox"
+require "spec_helper"
 
 describe Fog::Brightbox::Storage::AuthenticationRequest do
   include StockStorageResponses

--- a/spec/fog/storage/brightbox_spec.rb
+++ b/spec/fog/storage/brightbox_spec.rb
@@ -1,6 +1,4 @@
-require "minitest/autorun"
-require "webmock/minitest"
-require "fog/brightbox"
+require "spec_helper"
 
 describe Fog::Storage::Brightbox do
   include StockStorageResponses


### PR DESCRIPTION
Executing the test suite like:

```
find spec/ -name *_spec.rb -exec ruby -Ilib:spec {} \;
```

should always work. But currently, it fails at several occasions. This PR fixes the issues. Also note that even calling the test suite as ```rspec spec``` might randomly fail without these patches.