### PR TITLE
Gemfile to fix `net-ssh` dependency for Ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ rvm:
   - 2.2.0
   - 2.1.5
   - 2.0.0
-  - 1.9.3
 matrix:
   include:
     - rvm: 1.8.7
       gemfile: gemfiles/Gemfile.1.8.7
+    - rvm: 1.9.3
+      gemfile: gemfiles/Gemfile.1.9.3

--- a/gemfiles/Gemfile.1.9.3
+++ b/gemfiles/Gemfile.1.9.3
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "net-ssh", "< 3.0"
+
+gemspec :path => ".."


### PR DESCRIPTION
This adds `gemfiles/Gemfile.1.9.3` which is required for testing with
Ruby 1.9.3 since Net::SSH > 3.0 has dropped support for Ruby 1.9.3