### PR TITLE
Including `json` in 1.8.7 Gemfile

### DIFF
--- a/gemfiles/Gemfile.1.8.7
+++ b/gemfiles/Gemfile.1.8.7
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem "fog-core", :github => "fog/fog-core"
+gem "json"
 gem "mime-types", "~> 1.22"
 gem "inflecto", "~> 0.0.2"
 


### PR DESCRIPTION
Not sure why this is erring on Travis but working fine locally. Webmock
appears to doing `require "json"` and we need to specifically bundle
that as well.

However locally this is not behaving the same unless specifically adding
it to the spec helper.