### PR TITLE
Update README to reflect the fog-brightbox repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,7 @@ specify in your application's `Gemfile`
 
 ## Contributing
 
-`fog` modules are kept within the main repo.
-
-1. Fork it ( http://github.com/fog/fog/fork )
+1. Fork it ( http://github.com/fog/fog-brightbox/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ specify in your application's `Gemfile`
 
 ## Contributing
 
-1. Fork it ( http://github.com/fog/fog-brightbox/fork )
+1. Fork it ( https://github.com/fog/fog-brightbox/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)


### PR DESCRIPTION
Just a small fix for the README.