### PR TITLE
🏠 Set homepage URL to the gemspec

### DIFF
--- a/fog-brightbox.gemspec
+++ b/fog-brightbox.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q(Module for the 'fog' gem to support Brightbox Cloud)
   spec.summary       = %q(This library can be used as a module for `fog` or as standalone provider
                         to use the Brightbox Cloud in applications)
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/fog/fog-brightbox"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)


### PR DESCRIPTION
This gemspec misses homepage where [other](https://github.com/fog/fog-aws/blob/master/fog-aws.gemspec) [aws-*](https://github.com/fog/fog-google/blob/master/fog-google.gemspec) [gems](https://github.com/fog/fog-openstack/blob/master/fog-openstack.gemspec) [basically](https://github.com/fog/fog-core/blob/master/fog-core.gemspec) [know](https://github.com/fog/fog-azure/blob/master/fog-azure.gemspec) [their](https://github.com/fog/fog-softlayer/blob/master/fog-softlayer.gemspec) [homepage](https://github.com/fog/fog-xml/blob/master/fog-xml.gemspec).
