### PR TITLE
Fix `public_suffix` dependency

### DIFF
--- a/gemfiles/Gemfile.1.9.3
+++ b/gemfiles/Gemfile.1.9.3
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+# Some other dependencies are clashing on this
+gem "public_suffix", "~> 1.4.6"
 gem "net-ssh", "< 3.0"
 
 gemspec :path => ".."

--- a/gemfiles/Gemfile.1.9.3
+++ b/gemfiles/Gemfile.1.9.3
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 # Some other dependencies are clashing on this
 gem "public_suffix", "~> 1.4.6"
 gem "net-ssh", "< 3.0"
+gem "webmock", "~> 2.3.2"
 
 gemspec :path => ".."


### PR DESCRIPTION
A number of gems like rake, builder and coderay are installed on Travis
but pull in a Ruby 2+ only version of `public_suffix`

I had hoped Fog 2.0 would have been out by now to drop support
officially.