### PR TITLE
This passes through `cloud_ip` to `Server.create`

### DIFF
--- a/lib/fog/brightbox/models/compute/server.rb
+++ b/lib/fog/brightbox/models/compute/server.rb
@@ -32,6 +32,7 @@ module Fog
         attribute :image_id,    :aliases => "image",        :squash => "id"
 
         attribute :snapshots
+        attribute :cloud_ip # Creation option only
         attribute :cloud_ips
         attribute :interfaces
         attribute :server_groups
@@ -186,6 +187,7 @@ module Fog
           }.delete_if { |_k, v| v.nil? || v == "" }
 
           options.merge!(:server_type => flavor_id) unless flavor_id.nil? || flavor_id == ""
+          options.merge!(:cloud_ip => cloud_ip) unless cloud_ip.nil? || cloud_ip == ""
 
           data = service.create_server(options)
           merge_attributes(data)


### PR DESCRIPTION
It is now possible to request the immediate mapping of a Cloud IP
following a completed server build.

If there is an existing Cloud IP to use the following is supported:

    connection.servers.create(:cloud_up => "cip-12345")

If a new Cloud IP is required the alternative can be used.

    connection.servers.create(:cloud_up => true)