### PR TITLE
Workaround for using old bundler on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ rvm:
   - 2.2.0
   - 2.1.5
   - 2.0.0
+before_install:
+  - gem install bundler
 matrix:
   include:
     - rvm: 1.9.3


### PR DESCRIPTION
Getting:

    NoMethodError: undefined method `spec' for nil:NilClass

From Travis because of changes made in Bundler.