### PR TITLE
Expose Cloud IPv6 in API

### DIFF
--- a/lib/fog/brightbox/models/compute/cloud_ip.rb
+++ b/lib/fog/brightbox/models/compute/cloud_ip.rb
@@ -12,6 +12,8 @@ module Fog
 
         attribute :reverse_dns
         attribute :public_ip
+        attribute :public_ipv4
+        attribute :public_ipv6
         attribute :fqdn
 
         # Links - to be replaced


### PR DESCRIPTION
Alongside the legacy form of `public_ip` this adds the following
attributes to the Cloud IP model:

* `public_ipv4` (clarifying which version it represents)
* `public_ipv6`

This allows access to the values exposed in the API update.