### PR TITLE
Changes to `#create_temp_url` with missing URL

### DIFF
--- a/lib/fog/brightbox/requests/storage/get_object_https_url.rb
+++ b/lib/fog/brightbox/requests/storage/get_object_https_url.rb
@@ -15,63 +15,6 @@ module Fog
         def get_object_https_url(container, object, expires, options = {})
           create_temp_url(container, object, expires, "GET", options.merge(:scheme => "https"))
         end
-
-        # creates a temporary url
-        #
-        # @param container [String] Name of container containing object
-        # @param object [String] Name of object to get expiring url for
-        # @param expires_at [Time] An expiry time for this url
-        # @param method [String] The method to use for accessing the object (GET, PUT, HEAD)
-        # @param options [Hash] An optional options hash
-        # @option options [String] :scheme The scheme to use (http, https)
-        # @option options [String] :port A non standard port to use
-        #
-        # @return [String] url for object
-        #
-        # @raise [ArgumentError] if +storage_temp_key+ is not set in configuration
-        # @raise [ArgumentError] if +method+ is not valid
-        #
-        # @see http://docs.rackspace.com/files/api/v1/cf-devguide/content/Create_TempURL-d1a444.html
-        #
-        def create_temp_url(container, object, expires_at, method, options = {})
-          raise ArgumentError, "Storage must be instantiated with the :brightbox_temp_url_key option" if @config.storage_temp_key.nil?
-
-          # POST not allowed
-          allowed_methods = %w(GET PUT HEAD)
-          unless allowed_methods.include?(method)
-            raise ArgumentError.new("Invalid method '#{method}' specified. Valid methods are: #{allowed_methods.join(", ")}")
-          end
-
-          # This assumes we have access to the management URL at this point
-          destination_url = management_url.dup
-          object_path = destination_url.path
-
-          destination_url.scheme = options[:scheme] if options[:scheme]
-          destination_url.port = options[:port] if options[:port]
-
-          object_path_escaped = "#{object_path}/#{Fog::Storage::Brightbox.escape(container)}/#{Fog::Storage::Brightbox.escape(object, "/")}"
-          object_path_unescaped = "#{object_path}/#{Fog::Storage::Brightbox.escape(container)}/#{object}"
-
-          expiry_timestamp = expires_at.to_i
-          string_to_sign = [method, expiry_timestamp, object_path_unescaped].join("\n")
-
-          hmac = Fog::HMAC.new("sha1", @config.storage_temp_key)
-          sig = sig_to_hex(hmac.sign(string_to_sign))
-
-          destination_url.path = object_path_escaped
-          destination_url.query = URI.encode_www_form(:temp_url_sig => sig, :temp_url_expires => expiry_timestamp)
-          destination_url.to_s
-        end
-
-        private
-
-        def sig_to_hex(str)
-          str.unpack("C*").map { |c|
-            c.to_s(16)
-          }.map { |h|
-            h.size == 1 ? "0#{h}" : h
-          }.join
-        end
       end
     end
   end

--- a/lib/fog/brightbox/storage.rb
+++ b/lib/fog/brightbox/storage.rb
@@ -6,7 +6,8 @@ module Fog
       recognizes :persistent, :brightbox_service_name,
                  :brightbox_storage_url,
                  :brightbox_service_type, :brightbox_tenant,
-                 :brightbox_region, :brightbox_temp_url_key
+                 :brightbox_region, :brightbox_temp_url_key,
+                 :brightbox_storage_management_url
 
       model_path "fog/brightbox/models/storage"
       model :directory
@@ -123,7 +124,66 @@ module Fog
           url.path.split("/")[2]
         end
 
+        # creates a temporary url
+        #
+        # @param container [String] Name of container containing object
+        # @param object [String] Name of object to get expiring url for
+        # @param expires_at [Time] An expiry time for this url
+        # @param method [String] The method to use for accessing the object (GET, PUT, HEAD)
+        # @param options [Hash] An optional options hash
+        # @option options [String] :scheme The scheme to use (http, https)
+        # @option options [String] :port A non standard port to use
+        #
+        # @return [String] url for object
+        #
+        # @raise [ArgumentError] if +storage_temp_key+ is not set in configuration
+        # @raise [ArgumentError] if +method+ is not valid
+        #
+        # @see http://docs.rackspace.com/files/api/v1/cf-devguide/content/Create_TempURL-d1a444.html
+        #
+        def create_temp_url(container, object, expires_at, method, options = {})
+          raise ArgumentError, "Storage must be instantiated with the :brightbox_temp_url_key option" if @config.storage_temp_key.nil?
+
+          # POST not allowed
+          allowed_methods = %w(GET PUT HEAD)
+          unless allowed_methods.include?(method)
+            raise ArgumentError.new("Invalid method '#{method}' specified. Valid methods are: #{allowed_methods.join(", ")}")
+          end
+
+          if management_url.nil?
+            message = "Storage must be instantiated with the :brightbox_storage_management_url or you must authenticate first"
+            raise Fog::Brightbox::Storage::ManagementUrlUnknown, message
+          end
+
+          destination_url = management_url.dup
+          object_path = destination_url.path
+
+          destination_url.scheme = options[:scheme] if options[:scheme]
+          destination_url.port = options[:port] if options[:port]
+
+          object_path_escaped = "#{object_path}/#{Fog::Storage::Brightbox.escape(container)}/#{Fog::Storage::Brightbox.escape(object, "/")}"
+          object_path_unescaped = "#{object_path}/#{Fog::Storage::Brightbox.escape(container)}/#{object}"
+
+          expiry_timestamp = expires_at.to_i
+          string_to_sign = [method, expiry_timestamp, object_path_unescaped].join("\n")
+
+          hmac = Fog::HMAC.new("sha1", @config.storage_temp_key)
+          sig = sig_to_hex(hmac.sign(string_to_sign))
+
+          destination_url.path = object_path_escaped
+          destination_url.query = URI.encode_www_form(:temp_url_sig => sig, :temp_url_expires => expiry_timestamp)
+          destination_url.to_s
+        end
+
         private
+
+        def sig_to_hex(str)
+          str.unpack("C*").map { |c|
+            c.to_s(16)
+          }.map { |h|
+            h.size == 1 ? "0#{h}" : h
+          }.join
+        end
 
         def update_config_from_auth_response(response)
           @config.update_tokens(response.access_token)

--- a/spec/fog/storage/brightbox_spec.rb
+++ b/spec/fog/storage/brightbox_spec.rb
@@ -317,4 +317,26 @@ describe Fog::Storage::Brightbox do
         service.create_temp_url(container, object, expiry_time, request_method, :scheme => "http", :port => 401)
     end
   end
+
+  describe "when initialised without management URL" do
+    before { skip unless RUBY_VERSION > "1.9.3" }
+    let(:temp_url_key) { "1234567890" }
+    let(:settings) do
+      {
+        :brightbox_client_id => "cli-12345",
+        :brightbox_secret => "12345",
+        :brightbox_temp_url_key => temp_url_key
+      }
+    end
+    let(:container) { "container" }
+    let(:object) { "file.ext" }
+    let(:expiry_time) { Time.utc(2012) }
+    let(:request_method) { "GET" }
+
+    it "raises an error" do
+      assert_raises Fog::Brightbox::Storage::ManagementUrlUnknown do
+        service.create_temp_url(container, object, expiry_time, request_method, :scheme => "https")
+      end
+    end
+  end
 end


### PR DESCRIPTION
The `management_url` is normally read from the authentication response
but an error would occur if called out of sequence. However, the error
was unclear relating to `NilClass`.

The method at fault was buried under the "requests" area and was implied
it was used during HTTP requests and so authentication must always have
happened. This moves the source of the method to the main service file.

This now raises `Fog::Brightbox::Storage::ManagementUrlUnknown` if the
`management_url` has not been either configured OR set by
authentication.

The `:brightbox_storage_management_url` is also "recognized" to not give
a warning if set as part of a configuration.

GH-41