### PR TITLE
Switch to `dry-inflector` gem

### DIFF
--- a/fog-brightbox.gemspec
+++ b/fog-brightbox.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "fog-core"
   spec.add_dependency "fog-json"
-  spec.add_dependency "inflecto"
+  spec.add_dependency "dry-inflector"
   spec.add_dependency "mime-types"
 
   spec.add_development_dependency "bundler"

--- a/lib/fog/brightbox/model_helper.rb
+++ b/lib/fog/brightbox/model_helper.rb
@@ -1,14 +1,20 @@
-require "inflecto"
+require "dry/inflector"
 
 module Fog
   module Brightbox
     module ModelHelper
       def resource_name
-        Inflecto.underscore(Inflecto.demodulize(self.class))
+        inflector.underscore(inflector.demodulize(self.class))
       end
 
       def collection_name
-        Inflecto.pluralize(resource_name)
+        inflector.pluralize(resource_name)
+      end
+
+      private
+
+      def inflector
+        @inflector ||= Dry::Inflector.new
       end
     end
   end


### PR DESCRIPTION
`inflecto` has been abandoned and `dry-inflector` is its replacement.

This was originally part of a version 1.0 release candidate but was back-ported.

It covers the change in PR #43