### PR TITLE
Fix "deprecation" warnings due to autoloading late

### DIFF
--- a/lib/fog/brightbox.rb
+++ b/lib/fog/brightbox.rb
@@ -11,9 +11,6 @@ module Fog
   module Brightbox
     extend Fog::Provider
 
-    service(:compute, "Compute")
-    service(:storage, "Storage")
-
     module Compute
       autoload :Config, File.expand_path("../brightbox/compute/config", __FILE__)
       autoload :ImageSelector, File.expand_path("../brightbox/compute/image_selector", __FILE__)
@@ -34,6 +31,9 @@ module Fog
     autoload :Model, File.expand_path("../brightbox/model", __FILE__)
     autoload :ModelHelper, File.expand_path("../brightbox/model_helper", __FILE__)
     autoload :OAuth2, File.expand_path("../brightbox/oauth2", __FILE__)
+
+    service(:compute, "Compute")
+    service(:storage, "Storage")
   end
 
   module Compute


### PR DESCRIPTION
The `Fog.service` declaration has changed in later versions of
`fog-core` and attempts to `eval` constants to see if they exist and
fall back to the older naming scheme if not.

However, it used to work as in our case, the service was declared and
autoloading set up afterwards.

This changes the order to avoid issues with the core behaviour change.