### PR TITLE
Use `example.test` for testing domains

### DIFF
--- a/spec/fog/brightbox/config_spec.rb
+++ b/spec/fog/brightbox/config_spec.rb
@@ -220,7 +220,7 @@ describe Fog::Brightbox::Config do
       @options = {
         :brightbox_client_id => "app-12345",
         :brightbox_secret => "12345",
-        :brightbox_username => "user@example.com",
+        :brightbox_username => "user@example.test",
         :brightbox_password => "12345"
       }
       @config = Fog::Brightbox::Config.new(@options)
@@ -241,7 +241,7 @@ describe Fog::Brightbox::Config do
 
   describe "when setting management_url with URI" do
     it "sets it correctly" do
-      uri = URI.parse("https://example.com")
+      uri = URI.parse("https://example.test")
       @config = Fog::Brightbox::Config.new
       @config.storage_management_url = uri
       assert_equal @config.storage_management_url, uri
@@ -250,7 +250,7 @@ describe Fog::Brightbox::Config do
 
   describe "when setting management_url with String" do
     it "raises ArgumentError" do
-      uri = "http://example.com/wrong"
+      uri = "http://example.test/wrong"
       assert_raises(ArgumentError) { Fog::Brightbox::Config.new.storage_management_url = uri }
     end
   end

--- a/spec/fog/brightbox/link_helper_spec.rb
+++ b/spec/fog/brightbox/link_helper_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Fog::Brightbox::LinkHelper do
   describe "when initialized with an RFC5988 value" do
     before do
-      @header = "<https://www.example.com/1.0/images/img-12345>; rel=snapshot"
+      @header = "<https://www.example.test/1.0/images/img-12345>; rel=snapshot"
       @helper = Fog::Brightbox::LinkHelper.new(@header)
     end
 

--- a/spec/fog/brightbox/storage/authentication_request_spec.rb
+++ b/spec/fog/brightbox/storage/authentication_request_spec.rb
@@ -47,7 +47,7 @@ describe Fog::Brightbox::Storage::AuthenticationRequest do
       stub_request(:get, "https://orbit.brightbox.com/v1").
         with(:headers => {
                "Host" => "orbit.brightbox.com:443",
-               "X-Auth-User" => "user@example.com",
+               "X-Auth-User" => "user@example.test",
                "X-Auth-Key" => "abcde"
              }).to_return(authorized_response)
     end
@@ -56,7 +56,7 @@ describe Fog::Brightbox::Storage::AuthenticationRequest do
       settings = {
         :brightbox_client_id => "app-12345",
         :brightbox_secret => "12345",
-        :brightbox_username => "user@example.com",
+        :brightbox_username => "user@example.test",
         :brightbox_password => "abcde"
       }
       @config = Fog::Brightbox::Config.new(settings)
@@ -70,7 +70,7 @@ describe Fog::Brightbox::Storage::AuthenticationRequest do
       stub_request(:get, "https://orbit.brightbox.com/v1").
         with(:headers => {
                "Host" => "orbit.brightbox.com:443",
-               "X-Auth-User" => "user@example.com",
+               "X-Auth-User" => "user@example.test",
                "X-Auth-Key" => "abcde"
              }).to_return(unauthorized_response)
     end
@@ -79,7 +79,7 @@ describe Fog::Brightbox::Storage::AuthenticationRequest do
       settings = {
         :brightbox_client_id => "app-12345",
         :brightbox_secret => "12345",
-        :brightbox_username => "user@example.com",
+        :brightbox_username => "user@example.test",
         :brightbox_password => "abcde"
       }
       @config = Fog::Brightbox::Config.new(settings)

--- a/spec/fog/storage/brightbox_spec.rb
+++ b/spec/fog/storage/brightbox_spec.rb
@@ -89,7 +89,7 @@ describe Fog::Brightbox::Storage do
       {
         :brightbox_client_id => "app-12345",
         :brightbox_secret => "12345",
-        :brightbox_username => "user@example.com",
+        :brightbox_username => "user@example.test",
         :brightbox_password => "abcde",
         :brightbox_account => "acc-abcde"
       }
@@ -111,7 +111,7 @@ describe Fog::Brightbox::Storage do
       {
         :brightbox_client_id => "app-12345",
         :brightbox_secret => "12345",
-        :brightbox_username => "user@example.com",
+        :brightbox_username => "user@example.test",
         :brightbox_password => "abcde"
       }
     end
@@ -204,7 +204,7 @@ describe Fog::Brightbox::Storage do
       {
         :brightbox_client_id => "app-12345",
         :brightbox_secret => "12345",
-        :brightbox_username => "user@example.com",
+        :brightbox_username => "user@example.test",
         :brightbox_password => "12345",
         :brightbox_access_token => "1234567890abcdefghijklmnopqrstuvwxyz",
         :brightbox_refresh_token => "1234567890abcdefghijklmnopqrstuvwxyz",
@@ -221,7 +221,7 @@ describe Fog::Brightbox::Storage do
 
       # The reauthentication
       stub_request(:get, "https://files.gb2.brightbox.com/v1").
-        with(:headers => { "X-Auth-User" => "user@example.com", "X-Auth-Key" => "12345" }).
+        with(:headers => { "X-Auth-User" => "user@example.test", "X-Auth-Key" => "12345" }).
         to_return(authorized_response)
 
       # Repeated request

--- a/tests/brightbox/compute_tests.rb
+++ b/tests/brightbox/compute_tests.rb
@@ -9,8 +9,8 @@ end
 Shindo.tests("Fog::Compute.new", ["brightbox"]) do
   tests("service options") do
     {
-      :brightbox_api_url => "https://example.com",
-      :brightbox_auth_url => "https://example.com",
+      :brightbox_api_url => "https://example.test",
+      :brightbox_auth_url => "https://example.test",
       :brightbox_client_id => "app-12345",
       :brightbox_secret => "12345abdef6789",
       :brightbox_username => "user-12345",

--- a/tests/brightbox/requests/compute/collaboration_tests.rb
+++ b/tests/brightbox/requests/compute/collaboration_tests.rb
@@ -2,7 +2,7 @@ Shindo.tests("Fog::Compute[:brightbox] | collaboration requests", ["brightbox"])
   tests("success") do
     tests("#create_collaboration") do
       pending if Fog.mocking?
-      collaboration = Fog::Compute[:brightbox].create_collaboration(:email => "paul@example.com", :role => "admin")
+      collaboration = Fog::Compute[:brightbox].create_collaboration(:email => "paul@example.test", :role => "admin")
       @collaboration_id = collaboration["id"]
       formats(Brightbox::Compute::Formats::Full::COLLABORATION, false) { collaboration }
     end


### PR DESCRIPTION
Whilst `example.com` is a reserved domain per RFC2606 it was updated in
RFC6761 (https://tools.ietf.org/html/rfc6761) to be intended for
documentation rather than testing.

The `example.test` domain is intended for testing and should not be
routable by DNS so using the domain is preferred to avoid unintended
traffic.