### PR TITLE
Use `FOG_TEST_COLLABORATOR_EMAIL` ENV setting

### DIFF
--- a/tests/brightbox/requests/compute/collaboration_tests.rb
+++ b/tests/brightbox/requests/compute/collaboration_tests.rb
@@ -1,8 +1,11 @@
 Shindo.tests("Fog::Compute[:brightbox] | collaboration requests", ["brightbox"]) do
   tests("success") do
+    @test_collaborator_email = ENV["FOG_TEST_COLLABORATOR_EMAIL"]
+    pending unless @test_collaborator_email
+
     tests("#create_collaboration") do
       pending if Fog.mocking?
-      collaboration = Fog::Compute[:brightbox].create_collaboration(:email => "paul@example.test", :role => "admin")
+      collaboration = Fog::Compute[:brightbox].create_collaboration(:email => @test_collaborator_email, :role => "admin")
       @collaboration_id = collaboration["id"]
       formats(Brightbox::Compute::Formats::Full::COLLABORATION, false) { collaboration }
     end


### PR DESCRIPTION
Rather than trigger problems in mail relays trying to process the
non-resolvable `.invalid` domain, this will skip the collaboration tests
unless the `FOG_TEST_COLLABORATOR_EMAIL` setting is passed in to the
testing environment from the shell.