### PR TITLE
Add `status` check to `ImageSelector`

### DIFF
--- a/lib/fog/brightbox/compute/image_selector.rb
+++ b/lib/fog/brightbox/compute/image_selector.rb
@@ -28,6 +28,7 @@ module Fog
         def latest_ubuntu
           @images.select do |img|
             img["official"] == true &&
+              img["status"] == "available" &&
               img["arch"] == "i686" &&
               img["name"] =~ /ubuntu/i
           end.sort do |a, b|
@@ -46,7 +47,8 @@ module Fog
         def official_minimal
           @images.select do |img|
             img["official"] == true &&
-            img["virtual_size"] != 0
+              img["status"] == "available" &&
+              img["virtual_size"] != 0
           end.sort_by do |img|
             img["disk_size"]
           end.first["id"]


### PR DESCRIPTION
The image selector, when given a list of images filters them to find the
most suitable type to use in a test.

The images API returns deleted resources for 1 hour so they can be seen
(and that their state has changed) before fading away.

A rare failure happened internally when the `official_minimal` image was
decommisioned within an hour of the test running and so the helper chose
an image to test with that immediately returned an error when trying to
create a server from the removed image.

This adds a check for `status == "available"` in the filtering so that
the helper will get an image that will not immediately error.