### PR TITLE
Fix creation of database servers from snapshot

### DIFF
--- a/lib/fog/brightbox/models/compute/database_server.rb
+++ b/lib/fog/brightbox/models/compute/database_server.rb
@@ -34,6 +34,8 @@ module Fog
         attribute :flavor_id, "alias" => "database_server_type", :squash => "id"
         attribute :zone_id, "alias" => "zone", :squash => "id"
 
+        attribute :snapshot_id
+
         attribute :cloud_ips
 
         def save
@@ -54,6 +56,7 @@ module Fog
             options[:version] = database_version if database_version
             options[:database_type] = flavor_id if flavor_id
             options[:zone] = zone_id if zone_id
+            options[:snapshot] = snapshot_id if snapshot_id
 
             data = create_database_server(options)
           end

--- a/spec/fog/compute/brightbox/database_server_spec.rb
+++ b/spec/fog/compute/brightbox/database_server_spec.rb
@@ -19,7 +19,7 @@ describe Fog::Brightbox::Compute::DatabaseServer do
     end
   end
 
-  describe "when snapshotting withi no options" do
+  describe "when snapshotting with no options" do
     it "returns the database server" do
       stub_request(:post, "http://localhost/1.0/database_servers/dbs-12345/snapshot").
         with(:query => hash_including(:account_id),
@@ -45,6 +45,21 @@ describe Fog::Brightbox::Compute::DatabaseServer do
         to_return(:status => 200, :body => %q({"id": "dbs-12345"}))
       @database_server = Fog::Brightbox::Compute::DatabaseServer.new(:service => service, :id => "dbs-12345")
       assert_kind_of Fog::Brightbox::Compute::DatabaseSnapshot, @database_server.snapshot(true)
+    end
+  end
+
+  describe "when building from a snapshot" do
+    it "returns the new SQL instance" do
+      stub_request(:post, "http://localhost/1.0/database_servers").
+        with(:query => hash_including(:account_id),
+             :headers => { "Authorization" => "Bearer FAKECACHEDTOKEN" },
+             :body => hash_including(:snapshot => "dbi-lv426")).
+        to_return(:status => 202, :body => %q({"id": "dbs-12345"}))
+
+      @database_server = Fog::Brightbox::Compute::DatabaseServer.new(:service => service, :snapshot_id => "dbi-lv426")
+      @database_server.save
+      assert_kind_of Fog::Brightbox::Compute::DatabaseServer, @database_server
+      assert_equal "dbs-12345", @database_server.id
     end
   end
 end


### PR DESCRIPTION
The `snapshot_id` was not set up on the model which meant that passing
in a snapshot ID was incorrectly creating a new instance rather than
recreating a database from a snapshot.

Without the attribute, it was filtering out the required option in the
real API call but that calls would work if performed using requests.