### PR TITLE
Add `LoadBalancer#ssl_minimum_version`

### DIFF
--- a/lib/fog/brightbox/models/compute/load_balancer.rb
+++ b/lib/fog/brightbox/models/compute/load_balancer.rb
@@ -18,6 +18,8 @@ module Fog
         attribute :healthcheck
         attribute :listeners
 
+        attribute :ssl_minimum_version
+
         # These SSL attributes act only as setters. You can not read certs or keys via the API
         attribute :certificate_pem
         attribute :certificate_private_key
@@ -58,6 +60,7 @@ module Fog
             :buffer_size => buffer_size,
             :certificate_pem => certificate_pem,
             :certificate_private_key => certificate_private_key,
+            :ssl_minimum_version => ssl_minimum_version,
             :sslv3 => ssl3?
           }.delete_if { |_k, v| v.nil? || v == "" }
           data = service.create_load_balancer(options)

--- a/spec/fog/compute/brightbox/load_balancer_spec.rb
+++ b/spec/fog/compute/brightbox/load_balancer_spec.rb
@@ -18,4 +18,28 @@ describe Fog::Brightbox::Compute::LoadBalancer do
       assert_equal "load_balancer", subject.resource_name
     end
   end
+
+  describe "when creating" do
+    it "send correct JSON" do
+      options = {
+        healthcheck: {},
+        listeners: [
+          {
+            protocol: "http",
+            in: 80,
+            out: 80
+          }
+        ],
+        nodes: []
+      }
+
+      stub_request(:post, "http://localhost/1.0/load_balancers").
+        with(:query => hash_including(:account_id),
+             :headers => { "Authorization" => "Bearer FAKECACHEDTOKEN" }).
+        to_return(:status => 202, :body => %q({"id": "lba-12345"}), :headers => {})
+
+      @load_balancer = Fog::Brightbox::Compute::LoadBalancer.new({ :service => service }.merge(options))
+      assert @load_balancer.save
+    end
+  end
 end


### PR DESCRIPTION
This attribute gets and sets the minimal TLS/SSL version to be supported
by the load balancer.