### PR TITLE
Add `Server#disk_encrypted`

### DIFF
--- a/lib/fog/brightbox/models/compute/server.rb
+++ b/lib/fog/brightbox/models/compute/server.rb
@@ -21,6 +21,8 @@ module Fog
         attribute :fqdn
         attribute :console_token
 
+        attribute :disk_encrypted
+
         # Times
         attribute :created_at, :type => :time
         attribute :started_at, :type => :time
@@ -188,6 +190,7 @@ module Fog
 
           options.merge!(:server_type => flavor_id) unless flavor_id.nil? || flavor_id == ""
           options.merge!(:cloud_ip => cloud_ip) unless cloud_ip.nil? || cloud_ip == ""
+          options.merge!(:disk_encrypted => disk_encrypted) if disk_encrypted
 
           data = service.create_server(options)
           merge_attributes(data)

--- a/spec/fog/compute/brightbox/server_spec.rb
+++ b/spec/fog/compute/brightbox/server_spec.rb
@@ -29,7 +29,7 @@ describe Fog::Brightbox::Compute::Server do
         stub_request(:post, "http://localhost/1.0/servers").
           with(:query => hash_including(:account_id),
                :headers => { "Authorization" => "Bearer FAKECACHEDTOKEN",
-                             "Content-Type": "application/json" },
+                             "Content-Type" => "application/json" },
                              :body => hash_including(:image => "img-12345")).
         to_return(:status => 202, :body => %q({"id":"srv-12345"}), :headers => {})
 
@@ -48,7 +48,7 @@ describe Fog::Brightbox::Compute::Server do
         stub_request(:post, "http://localhost/1.0/servers").
           with(:query => hash_including(:account_id),
                :headers => { "Authorization" => "Bearer FAKECACHEDTOKEN",
-                             "Content-Type": "application/json" },
+                             "Content-Type" => "application/json" },
                              :body => hash_including(:disk_encrypted => true)).
           to_return(:status => 202,
                     :body => %q({"id":"srv-12345","disk_encrypted":true}),

--- a/spec/fog/compute/brightbox/server_spec.rb
+++ b/spec/fog/compute/brightbox/server_spec.rb
@@ -19,7 +19,49 @@ describe Fog::Brightbox::Compute::Server do
     end
   end
 
-  describe "when snapshotting withi no options" do
+  describe "when creating" do
+    describe "with required image_id" do
+      it "sends correct JSON" do
+        options = {
+          image_id: "img-12345"
+        }
+
+        stub_request(:post, "http://localhost/1.0/servers").
+          with(:query => hash_including(:account_id),
+               :headers => { "Authorization" => "Bearer FAKECACHEDTOKEN",
+                             "Content-Type": "application/json" },
+                             :body => hash_including(:image => "img-12345")).
+        to_return(:status => 202, :body => %q({"id":"srv-12345"}), :headers => {})
+
+        @server = Fog::Brightbox::Compute::Server.new({ :service => service }.merge(options))
+        assert @server.save
+      end
+    end
+
+    describe "with additional disk_encrypted" do
+      it "sends correct JSON" do
+        options = {
+          image_id: "img-12345",
+          disk_encrypted: true
+        }
+
+        stub_request(:post, "http://localhost/1.0/servers").
+          with(:query => hash_including(:account_id),
+               :headers => { "Authorization" => "Bearer FAKECACHEDTOKEN",
+                             "Content-Type": "application/json" },
+                             :body => hash_including(:disk_encrypted => true)).
+          to_return(:status => 202,
+                    :body => %q({"id":"srv-12345","disk_encrypted":true}),
+                    :headers => {})
+
+        @server = Fog::Brightbox::Compute::Server.new({ :service => service }.merge(options))
+        assert @server.save
+        assert @server.disk_encrypted
+      end
+    end
+  end
+
+  describe "when snapshotting with no options" do
     it "returns the server" do
       stub_request(:post, "http://localhost/1.0/servers/srv-12345/snapshot").
         with(:query => hash_including(:account_id),


### PR DESCRIPTION
This attribute can be setup only during creation of a server. If enabled
the server is configured for encryption at rest using a LUKS volume.