### PR TITLE
Ruby 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 language: ruby
 rvm:
+  - 3.0
   - 2.7
   - 2.6
   - 2.5

--- a/fog-brightbox.gemspec
+++ b/fog-brightbox.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = "~> 2.0"
+  spec.required_ruby_version = ">= 2.0"
 
   spec.add_dependency "fog-core", ">= 1.45", "< 3.0"
   spec.add_dependency "fog-json"


### PR DESCRIPTION
`fog-brightbox` is currently declared as requiring `ruby ~> 2.0` which excludes Ruby 3.0.

When using Ruby 3.0 to install our `brightbox-cli` the dependency resolution will exclude our `3.x` series of CLI gems and is limited to the older `2.x` series.

So the dependency needs to be relaxed and any issues resolved so Ruby 3 can be used with the Brightbox CLI.