### PR TITLE
Fix passing database server's `snapshots_schedule`

### DIFF
--- a/lib/fog/brightbox/models/compute/database_server.rb
+++ b/lib/fog/brightbox/models/compute/database_server.rb
@@ -49,6 +49,9 @@ module Fog
           options[:maintenance_weekday] = maintenance_weekday
           options[:maintenance_hour] = maintenance_hour
 
+          options[:snapshots_schedule] = snapshots_schedule
+          options[:snapshots_schedule] = nil if snapshots_schedule == ""
+
           if persisted?
             data = update_database_server(options)
           else


### PR DESCRIPTION
The `snapshots_schedule` attribute was not passed through during `save`
so using the model interface would filter out the setting. That meant it
was impossible to declare it as `nil` to create without a schedule or to
disable one.

The fog DSL also mapped the nullable string to an empty string so it
needed converting to a @nil@ for the correct API behaviour.