### PR TITLE
Add support for `Volume` resources

### DIFF
--- a/lib/fog/brightbox/compute.rb
+++ b/lib/fog/brightbox/compute.rb
@@ -63,6 +63,8 @@ module Fog
       model :user
       collection :user_collaborations
       model :user_collaboration
+      collection :volumes
+      model :volume
 
       request_path "fog/brightbox/requests/compute"
       request :accept_user_collaboration
@@ -72,7 +74,9 @@ module Fog
       request :add_servers_server_group
       request :apply_to_firewall_policy
       request :accept_user_collaboration
+      request :attach_volume
       request :remove_firewall_policy
+      request :copy_volume
       request :create_api_client
       request :create_application
       request :create_cloud_ip
@@ -84,6 +88,7 @@ module Fog
       request :create_database_server
       request :create_server
       request :create_server_group
+      request :create_volume
       request :delete_api_client
       request :delete_application
       request :delete_cloud_ip
@@ -97,6 +102,8 @@ module Fog
       request :delete_server
       request :delete_server_group
       request :delete_user_collaboration
+      request :delete_volume
+      request :detach_volume
       request :get_account
       request :get_api_client
       request :get_application
@@ -117,6 +124,7 @@ module Fog
       request :get_server_type
       request :get_user
       request :get_user_collaboration
+      request :get_volume
       request :get_zone
       request :list_accounts
       request :list_api_clients
@@ -135,12 +143,14 @@ module Fog
       request :list_servers
       request :list_users
       request :list_user_collaborations
+      request :list_volumes
       request :list_zones
       request :lock_resource_database_server
       request :lock_resource_database_snapshot
       request :lock_resource_image
       request :lock_resource_load_balancer
       request :lock_resource_server
+      request :lock_resource_volume
       request :map_cloud_ip
       request :move_servers_server_group
       request :reboot_server
@@ -156,6 +166,7 @@ module Fog
       request :reset_secret_application
       request :reset_server
       request :resend_collaboration
+      request :resize_volume
       request :reject_user_collaboration
       request :shutdown_server
       request :snapshot_database_server
@@ -167,6 +178,7 @@ module Fog
       request :unlock_resource_image
       request :unlock_resource_load_balancer
       request :unlock_resource_server
+      request :unlock_resource_volume
       request :unmap_cloud_ip
       request :update_account
       request :update_api_client
@@ -182,6 +194,7 @@ module Fog
       request :update_server
       request :update_server_group
       request :update_user
+      request :update_volume
 
       # The Mock Service allows you to run a fake instance of the Service
       # which makes no real connections.

--- a/lib/fog/brightbox/models/compute/server.rb
+++ b/lib/fog/brightbox/models/compute/server.rb
@@ -7,6 +7,8 @@ module Fog
         include Fog::Brightbox::ModelHelper
         include Fog::Brightbox::Compute::ResourceLocking
 
+        attr_accessor :volume_id
+
         identity :id
         attribute :resource_type
         attribute :url
@@ -38,6 +40,7 @@ module Fog
         attribute :cloud_ips
         attribute :interfaces
         attribute :server_groups
+        attribute :volumes
         attribute :zone
         attribute :server_type
 
@@ -181,7 +184,6 @@ module Fog
           raise Fog::Errors::Error.new("Resaving an existing object may create a duplicate") if persisted?
           requires :image_id
           options = {
-            :image => image_id,
             :name => name,
             :zone => zone_id,
             :user_data => user_data,
@@ -191,6 +193,12 @@ module Fog
           options.merge!(:server_type => flavor_id) unless flavor_id.nil? || flavor_id == ""
           options.merge!(:cloud_ip => cloud_ip) unless cloud_ip.nil? || cloud_ip == ""
           options.merge!(:disk_encrypted => disk_encrypted) if disk_encrypted
+
+          if volume_id
+            options.merge!(:volumes => [:volume => volume_id])
+          else
+            options.merge!(:image => image_id)
+          end
 
           data = service.create_server(options)
           merge_attributes(data)

--- a/lib/fog/brightbox/models/compute/volume.rb
+++ b/lib/fog/brightbox/models/compute/volume.rb
@@ -1,0 +1,152 @@
+module Fog
+  module Brightbox
+    class Compute
+      class Volume < Fog::Brightbox::Model
+        include Fog::Brightbox::Compute::ResourceLocking
+
+        identity :id
+        attribute :url
+        attribute :resource_type
+
+        attribute :name
+        attribute :state, :aliases => "status"
+
+        attribute :description
+        attribute :filesystem_label
+        attribute :filesystem_type
+        attribute :serial
+        attribute :size
+        attribute :source
+        attribute :source_type
+        attribute :storage_type
+
+        attribute :boot
+        attribute :delete_with_server
+        attribute :encrypted
+
+        # Times
+        attribute :created_at, :type => :time
+        attribute :updated_at, :type => :time
+        attribute :deleted_at, :type => :time
+
+        # Links
+        attribute :account_id, :aliases => "account", :squash => "id"
+        attribute :image_id, :aliases => "image", :squash => "id"
+        attribute :server_id, :aliases => "server", :squash => "id"
+
+        def attach(server)
+          requires :identity
+          data = service.attach_volume(identity, server: server.id)
+          merge_attributes(data)
+          true
+        end
+
+        def attached?
+          state == "attached"
+        end
+
+        # @param [Hash] options
+        # @option options [Boolean] :delete_with_server Set +true+ the volume will be removed if attached to a server that is deleted
+        # @option options [String] :description
+        # @option options [String] :name
+        # @option options [String] :serial
+        #
+        # @return [Fog::Compute::Volume] a new model for the copy
+        def copy(options = {})
+          requires :identity
+          data = service.copy_volume(identity, options)
+          service.volumes.new(data)
+        end
+
+        def creating?
+          state == "creating"
+        end
+
+        def deleted?
+          state == "deleted"
+        end
+
+        def deleting?
+          state == "deleting"
+        end
+
+        def detach
+          requires :identity
+          data = service.detach_volume(identity)
+          merge_attributes(data)
+          true
+        end
+
+        def detached?
+          state == "detached"
+        end
+
+        def failed?
+          state == "failed"
+        end
+
+        def finished?
+          deleted? || failed?
+        end
+
+        def ready?
+          attached? || detached?
+        end
+
+        # @param [Hash] options
+        # @option options [Integer] :to The new size in MiB to change the volume to
+        def resize(options)
+          requires :identity
+
+          # The API requires the old "from" size to avoid acting on stale data
+          # We can merge this and if the API rejects the request, the model was out of sync
+          options.merge!(:from => size)
+
+          data = service.resize_volume(identity, options)
+          merge_attributes(data)
+          true
+        end
+
+        def save
+          if persisted?
+            options = {
+              :delete_with_server => delete_with_server,
+              :description => description,
+              :name => name,
+              :serial => serial
+            }.delete_if { |_k, v| v.nil? || v == "" }
+
+            data = service.update_volume(identity, options)
+          else
+            raise Fog::Errors::Error.new("'image_id' and 'filesystem_type' are mutually exclusive") if image_id && filesystem_type
+            raise Fog::Errors::Error.new("'image_id' or 'filesystem_type' is required") unless image_id || filesystem_type
+
+            options = {
+              :delete_with_server => delete_with_server,
+              :description => description,
+              :filesystem_label => filesystem_label,
+              :filesystem_type => filesystem_type,
+              :name => name,
+              :serial => serial,
+              :size => size
+            }.delete_if { |_k, v| v.nil? || v == "" }
+
+            options.merge!(:image => image_id) unless image_id.nil? || image_id == ""
+
+            data = service.create_volume(options)
+          end
+
+          merge_attributes(data)
+          true
+        end
+
+        def destroy
+          requires :identity
+          data = service.delete_volume(identity)
+          merge_attributes(data)
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/models/compute/volumes.rb
+++ b/lib/fog/brightbox/models/compute/volumes.rb
@@ -1,0 +1,23 @@
+require "fog/brightbox/models/compute/volume"
+
+module Fog
+  module Brightbox
+    class Compute
+      class Volumes < Fog::Collection
+        model Fog::Brightbox::Compute::Volume
+
+        def all
+          data = service.list_volumes
+          load(data)
+        end
+
+        def get(identifier)
+          data = service.get_volume(identifier)
+          new(data)
+        rescue Excon::Errors::NotFound
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/attach_volume.rb
+++ b/lib/fog/brightbox/requests/compute/attach_volume.rb
@@ -1,0 +1,23 @@
+module Fog
+  module Brightbox
+    class Compute
+      class Real
+        # Attach a detached server to a nominated server
+        #
+        # @param [String] identifier Unique reference to identify the resource
+        # @param [Hash] options
+        # @option options [Boolean] :nested passed through with the API request. When true nested resources are expanded.
+        # @option options [String] :server The identifier of the server
+        # @option options [Boolean] :boot Set +true+ to attach as boot volume. Only when server is stopped
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        # @return [NilClass] if no options were passed
+        #
+        def attach_volume(identifier, options)
+          return nil if identifier.nil? || identifier == ""
+          wrapped_request("post", "/1.0/volumes/#{identifier}/attach", [202], options)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/copy_volume.rb
+++ b/lib/fog/brightbox/requests/compute/copy_volume.rb
@@ -1,0 +1,25 @@
+module Fog
+  module Brightbox
+    class Compute
+      class Real
+        # Copy a volume and create a new one
+        #
+        # @param [String] identifier Unique reference to identify the resource
+        # @param [Hash] options
+        # @option options [Boolean] :nested passed through with the API request. When true nested resources are expanded.
+        # @option options [Boolean] :delete_with_server Set +true+ the volume will be removed if attached to a server that is deleted
+        # @option options [String] :description
+        # @option options [String] :name
+        # @option options [String] :serial
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        # @return [NilClass] if no options were passed
+        #
+        def copy_volume(identifier, options)
+          return nil if identifier.nil? || identifier == ""
+          wrapped_request("post", "/1.0/volumes/#{identifier}/copy", [202], options)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/create_volume.rb
+++ b/lib/fog/brightbox/requests/compute/create_volume.rb
@@ -1,0 +1,25 @@
+module Fog
+  module Brightbox
+    class Compute
+      class Real
+        # Create a new volume
+        #
+        # @param [String] identifier Unique reference to identify the resource
+        # @param [Hash] options
+        # @option options [Boolean] :nested passed through with the API request. When true nested resources are expanded.
+        # @option options [Boolean] :delete_with_server Set +true+ the volume will be removed if attached to a server that is deleted
+        # @option options [String] :description
+        # @option options [String] :name
+        # @option options [String] :serial
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        # @return [NilClass] if no options were passed
+        #
+        def create_volume(options)
+          return nil if options.empty? || options.nil?
+          wrapped_request("post", "/1.0/volumes", [202], options)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/delete_volume.rb
+++ b/lib/fog/brightbox/requests/compute/delete_volume.rb
@@ -1,0 +1,20 @@
+module Fog
+  module Brightbox
+    class Compute
+      class Real
+        # Destroy the volume and free up the resources.
+        #
+        # @param [String] identifier Unique reference to identify the resource
+        # @param [Hash] options
+        # @option options [Boolean] :nested passed through with the API request. When true nested resources are expanded.
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        #
+        def delete_volume(identifier, options = {})
+          return nil if identifier.nil? || identifier == ""
+          wrapped_request("delete", "/1.0/volumes/#{identifier}", [202], options)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/detach_volume.rb
+++ b/lib/fog/brightbox/requests/compute/detach_volume.rb
@@ -1,0 +1,21 @@
+module Fog
+  module Brightbox
+    class Compute
+      class Real
+        # Detach the volume from its server
+        #
+        # @param [String] identifier Unique reference to identify the resource
+        # @param [Hash] options
+        # @option options [Boolean] :nested passed through with the API request. When true nested resources are expanded.
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        # @return [NilClass] if no options were passed
+        #
+        def detach_volume(identifier, options = {})
+          return nil if identifier.nil? || identifier == ""
+          wrapped_request("post", "/1.0/volumes/#{identifier}/detach", [202], options)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/get_volume.rb
+++ b/lib/fog/brightbox/requests/compute/get_volume.rb
@@ -1,0 +1,20 @@
+module Fog
+  module Brightbox
+    class Compute
+      class Real
+        # Get full details of the volume.
+        #
+        # @param [String] identifier Unique reference to identify the resource
+        # @param [Hash] options
+        # @option options [Boolean] :nested passed through with the API request. When true nested resources are expanded.
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        #
+        def get_volume(identifier, options = {})
+          return nil if identifier.nil? || identifier == ""
+          wrapped_request("get", "/1.0/volumes/#{identifier}", [200], options)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/list_volumes.rb
+++ b/lib/fog/brightbox/requests/compute/list_volumes.rb
@@ -1,0 +1,18 @@
+module Fog
+  module Brightbox
+    class Compute
+      class Real
+        # Lists summary details of volumes available for use by the Account
+        #
+        # @param [Hash] options
+        # @option options [Boolean] :nested passed through with the API request. When true nested resources are expanded.
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        #
+        def list_volumes(options = {})
+          wrapped_request("get", "/1.0/volumes", [200], options)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/lock_resource_volume.rb
+++ b/lib/fog/brightbox/requests/compute/lock_resource_volume.rb
@@ -1,0 +1,18 @@
+module Fog
+  module Brightbox
+    class Compute
+      class Real
+        # @param [String] identifier Unique reference to identify the resource
+        # @param [Hash] options
+        # @option options [Boolean] :nested passed through with the API request. When true nested resources are expanded.
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        #
+        def lock_resource_volume(identifier, options = {})
+          return nil if identifier.nil? || identifier == ""
+          wrapped_request("put", "/1.0/volumes/#{identifier}/lock_resource", [200], options)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/resize_volume.rb
+++ b/lib/fog/brightbox/requests/compute/resize_volume.rb
@@ -1,0 +1,26 @@
+module Fog
+  module Brightbox
+    class Compute
+      class Real
+        # Resize a volume, currently limited to expanding volumes.
+        #
+        # Partitions will need to be expanded within the OS.
+        #
+        # @param [String] identifier Unique reference to identify the resource
+        # @param [Hash] options
+        # @option options [Boolean] :nested passed through with the API request. When true nested resources are expanded.
+        # @option options [Integer] :from The original size (in MiB) to act as a preflight check to prevent duplicate requests
+        # @option options [Integer] :to The new size in MiB to change the volume to
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        # @return [NilClass] if no options were passed
+        #
+        def resize_volume(identifier, options)
+          return nil if identifier.nil? || identifier == ""
+          return nil if options.empty? || options.nil?
+          wrapped_request("post", "/1.0/volumes/#{identifier}/resize", [202], options)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/unlock_resource_volume.rb
+++ b/lib/fog/brightbox/requests/compute/unlock_resource_volume.rb
@@ -1,0 +1,18 @@
+module Fog
+  module Brightbox
+    class Compute
+      class Real
+        # @param [String] identifier Unique reference to identify the resource
+        # @param [Hash] options
+        # @option options [Boolean] :nested passed through with the API request. When true nested resources are expanded.
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        #
+        def unlock_resource_volume(identifier, options = {})
+          return nil if identifier.nil? || identifier == ""
+          wrapped_request("put", "/1.0/volumes/#{identifier}/unlock_resource", [200], options)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/update_volume.rb
+++ b/lib/fog/brightbox/requests/compute/update_volume.rb
@@ -1,0 +1,26 @@
+module Fog
+  module Brightbox
+    class Compute
+      class Real
+        # Update some volume attributes.
+        #
+        # @param [String] identifier Unique reference to identify the resource
+        # @param [Hash] options
+        # @option options [Boolean] :nested passed through with the API request. When true nested resources are expanded.
+        # @option options [Boolean] :delete_with_server Set +true+ the volume will be removed if attached to a server that is deleted
+        # @option options [String] :description
+        # @option options [String] :name
+        # @option options [String] :serial
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        # @return [NilClass] if no options were passed
+        #
+        def update_volume(identifier, options)
+          return nil if identifier.nil? || identifier == ""
+          return nil if options.empty? || options.nil?
+          wrapped_request("put", "/1.0/volumes/#{identifier}", [202], options)
+        end
+      end
+    end
+  end
+end

--- a/spec/fog/compute/brightbox/volume_spec.rb
+++ b/spec/fog/compute/brightbox/volume_spec.rb
@@ -1,0 +1,348 @@
+require "spec_helper"
+require "fog/brightbox/models/compute/volume"
+
+describe Fog::Brightbox::Compute::Volume do
+  include ModelSetup
+  include SupportsResourceLocking
+
+  subject { service.volumes.new }
+
+  describe "when state is 'creating'" do
+    it do
+      subject.state = "creating"
+
+      assert subject.creating?
+      refute subject.attached?
+      refute subject.detached?
+      refute subject.deleting?
+      refute subject.deleted?
+      refute subject.failed?
+
+      refute subject.ready?
+      refute subject.finished?
+    end
+  end
+
+  describe "when state is 'attached'" do
+    it do
+      subject.state = "attached"
+
+      refute subject.creating?
+      assert subject.attached?
+      refute subject.detached?
+      refute subject.deleting?
+      refute subject.deleted?
+      refute subject.failed?
+
+      assert subject.ready?
+      refute subject.finished?
+    end
+  end
+
+  describe "when state is 'detached'" do
+    it do
+      subject.state = "detached"
+
+      refute subject.creating?
+      refute subject.attached?
+      assert subject.detached?
+      refute subject.deleting?
+      refute subject.deleted?
+      refute subject.failed?
+
+      assert subject.ready?
+      refute subject.finished?
+    end
+  end
+
+  describe "when state is 'deleting'" do
+    it do
+      subject.state = "deleting"
+
+      refute subject.creating?
+      refute subject.attached?
+      refute subject.detached?
+      assert subject.deleting?
+      refute subject.deleted?
+      refute subject.failed?
+
+      refute subject.ready?
+      refute subject.finished?
+    end
+  end
+
+  describe "when state is 'deleted'" do
+    it do
+      subject.state = "deleted"
+
+      refute subject.creating?
+      refute subject.attached?
+      refute subject.detached?
+      refute subject.deleting?
+      assert subject.deleted?
+      refute subject.failed?
+
+      refute subject.ready?
+      assert subject.finished?
+    end
+  end
+
+  describe "when state is 'failed'" do
+    it do
+      subject.state = "failed"
+
+      refute subject.creating?
+      refute subject.attached?
+      refute subject.detached?
+      refute subject.deleting?
+      refute subject.deleted?
+      assert subject.failed?
+
+      refute subject.ready?
+      assert subject.finished?
+    end
+  end
+
+  describe "#attach" do
+    it do
+      subject.id = "vol-12345"
+      assert subject.persisted?
+
+      server = service.servers.new
+      server.id = "srv-12345"
+
+      stub_request(:post, "http://localhost/1.0/volumes/vol-12345/attach").
+        with(:query => hash_including(:account_id),
+             :headers => { "Authorization" => "Bearer FAKECACHEDTOKEN",
+                          "Content-Type" => "application/json" },
+             :body => hash_including(:server => "srv-12345")).
+        to_return(:status => 202,
+                  :body => %q({"id":"vol-12345","status":"attached"}),
+                  :headers => {})
+
+      subject.attach(server)
+
+      assert subject.attached?
+    end
+  end
+
+  describe "#collection_name" do
+    it "responds 'volumes'" do
+      assert_equal "volumes", subject.collection_name
+    end
+  end
+
+  describe "#copy" do
+    it do
+      subject.id = "vol-12345"
+      subject.state = "attached"
+      subject.delete_with_server = false
+
+      refute subject.delete_with_server
+      assert subject.persisted?
+
+      stub_request(:post, "http://localhost/1.0/volumes/vol-12345/copy").
+        with(:query => hash_including(:account_id),
+             :headers => { "Authorization" => "Bearer FAKECACHEDTOKEN",
+                          "Content-Type" => "application/json" },
+             :body => hash_including(:delete_with_server => true)).
+        to_return(:status => 202,
+                  :body => %q({"id":"vol-abcde","delete_with_server":true,"name":"Copy of vol-12345 (Impish Image)","status":"detached"}),
+                  :headers => {})
+
+      copy = subject.copy(delete_with_server: true)
+
+      assert copy.persisted?
+      assert_equal "vol-abcde", copy.id
+      assert copy.delete_with_server
+      assert copy.detached?
+    end
+  end
+
+  describe "#detach" do
+    it do
+      subject.id = "vol-12345"
+      subject.state = "attached"
+
+      assert subject.persisted?
+
+      stub_request(:post, "http://localhost/1.0/volumes/vol-12345/detach").
+        with(:query => hash_including(:account_id),
+             :headers => { "Authorization" => "Bearer FAKECACHEDTOKEN",
+                          "Content-Type" => "application/json" }).
+        to_return(:status => 202,
+                  :body => %q({"id":"vol-12345","status":"detached"}),
+                  :headers => {})
+
+      subject.detach
+
+      assert subject.detached?
+    end
+  end
+
+  describe "#destroy" do
+    it do
+      subject.id = "vol-12345"
+      assert subject.persisted?
+
+      stub_request(:delete, "http://localhost/1.0/volumes/vol-12345").
+        with(:query => hash_including(:account_id),
+             :headers => { "Authorization" => "Bearer FAKECACHEDTOKEN",
+                           "Content-Type" => "application/json" }).
+        to_return(:status => 202,
+                  :body => %q({"id":"vol-12345","status":"deleting"}),
+                  :headers => {})
+
+      subject.destroy
+      assert_equal "deleting", subject.state
+    end
+  end
+
+  describe "#ready?" do
+    describe "when state is 'creating'" do
+      it do
+        subject.state = "creating"
+
+        refute subject.ready?
+      end
+    end
+
+    describe "when state is 'attached'" do
+      it do
+        subject.state = "attached"
+
+        assert subject.ready?
+      end
+    end
+
+    describe "when state is 'detached'" do
+      it do
+        subject.state = "detached"
+
+        assert subject.ready?
+      end
+    end
+  end
+
+  describe "#resize" do
+    it do
+      subject.id = "vol-12345"
+      subject.size = 40_000
+
+      assert subject.persisted?
+
+      stub_request(:post, "http://localhost/1.0/volumes/vol-12345/resize").
+        with(:query => hash_including(:account_id),
+             :headers => { "Authorization" => "Bearer FAKECACHEDTOKEN",
+                          "Content-Type" => "application/json" },
+             :body => hash_including(:from => 40_000, :to => 50_000)).
+        to_return(:status => 202,
+                  :body => %q({"id":"vol-12345","size": 50000}),
+                  :headers => {})
+
+      subject.resize(to: 50_000)
+
+      assert 50_000, subject.size
+    end
+  end
+
+  describe "#resource_name" do
+    it "responds 'volume'" do
+      assert_equal "volume", subject.resource_name
+    end
+  end
+
+  describe "#save" do
+    describe "when creating" do
+      describe "with mutually exclusive arguments" do
+        it "raises Fog::Errors::Error" do
+          options = {
+            filesystem_type: "ext4",
+            image_id: "img-12345"
+          }
+
+          @volume = Fog::Brightbox::Compute::Volume.new({ :service => service }.merge(options))
+
+          assert_raises Fog::Errors::Error do
+            @volume.save
+          end
+        end
+      end
+
+      describe "with filesytem type" do
+        it "sends correct JSON" do
+          options = {
+            description: "An ext4 volume",
+            filesystem_type: "ext4"
+          }
+
+          stub_request(:post, "http://localhost/1.0/volumes").
+            with(:query => hash_including(:account_id),
+                 :headers => { "Authorization" => "Bearer FAKECACHEDTOKEN",
+                               "Content-Type" => "application/json" },
+                 :body => hash_including(:filesystem_type => "ext4")).
+            to_return(:status => 202,
+                      :body => %q({"id":"vol-12345","image":{"id":"img-blank"}}),
+                      :headers => {})
+
+          @volume = Fog::Brightbox::Compute::Volume.new({ :service => service }.merge(options))
+          assert @volume.save
+          assert_equal @volume.filesystem_type, "ext4"
+          assert_equal @volume.image_id, "img-blank"
+          assert_equal @volume.description, "An ext4 volume"
+        end
+      end
+
+      describe "with image" do
+        it "sends correct JSON" do
+          options = {
+            image_id: "img-12345",
+            name: "My Volume"
+          }
+
+          stub_request(:post, "http://localhost/1.0/volumes").
+            with(:query => hash_including(:account_id),
+                 :headers => { "Authorization" => "Bearer FAKECACHEDTOKEN",
+                               "Content-Type" => "application/json" },
+                 :body => hash_including(:image => "img-12345")).
+            to_return(:status => 202,
+                      :body => %q({"id":"vol-12345","image":{"id":"img-12345"}}),
+                      :headers => {})
+
+
+          @volume = Fog::Brightbox::Compute::Volume.new({ :service => service }.merge(options))
+          assert @volume.save
+          assert_equal @volume.image_id, "img-12345"
+          assert_equal @volume.name, "My Volume"
+        end
+      end
+    end
+
+    describe "when updating" do
+      it do
+        subject.id = "vol-12345"
+
+        assert subject.persisted?
+
+        subject.delete_with_server = true
+        subject.description = "Updated description"
+        subject.name = "New name"
+        subject.serial = "NewSerial"
+
+        stub_request(:put, "http://localhost/1.0/volumes/vol-12345").
+          with(:query => hash_including(:account_id),
+               :headers => { "Authorization" => "Bearer FAKECACHEDTOKEN",
+                             "Content-Type" => "application/json" },
+               :body => hash_including(:delete_with_server => true,
+                                       :description => "Updated description",
+                                       :name => "New name",
+                                       :serial => "NewSerial")).
+          to_return(:status => 202,
+                    :body => %q({"id":"vol-12345"}),
+                    :headers => {})
+
+        subject.save
+      end
+    end
+  end
+end

--- a/tests/brightbox/compute/schema.rb
+++ b/tests/brightbox/compute/schema.rb
@@ -252,6 +252,29 @@ class Brightbox
           "inviter"         => Brightbox::Compute::Formats::Nested::USER
         }
 
+        VOLUME = {
+          "id"              => String,
+          "resource_type"   => String,
+          "url"             => String,
+          "status"          => String,
+          "name"            => Fog::Nullable::String,
+          "delete_with_server" => Fog::Boolean,
+          "description"     => Fog::Nullable::String,
+          "boot"            => Fog::Boolean,
+          "encrypted"       => Fog::Boolean,
+          "filesystem_label" => Fog::Nullable::String,
+          "filesystem_type" => Fog::Nullable::String,
+          "locked"          => Fog::Boolean,
+          "serial"          => String,
+          "size"            => Integer,
+          "source"          => Fog::Nullable::String,
+          "source_type"     => String,
+          "storage_type"    => String,
+          "created_at"      => String,
+          "updated_at"      => String,
+          "deleted_at"      => Fog::Nullable::String
+        }
+
         ZONE = {
           "id"              => String,
           "resource_type"   => String,
@@ -482,6 +505,29 @@ class Brightbox
           "inviter"         => Brightbox::Compute::Formats::Nested::USER
         }
 
+        VOLUME = {
+          "id"              => String,
+          "resource_type"   => String,
+          "url"             => String,
+          "status"          => String,
+          "name"            => Fog::Nullable::String,
+          "delete_with_server" => Fog::Boolean,
+          "description"     => Fog::Nullable::String,
+          "boot"            => Fog::Boolean,
+          "encrypted"       => Fog::Boolean,
+          "filesystem_label" => Fog::Nullable::String,
+          "filesystem_type" => Fog::Nullable::String,
+          "locked"          => Fog::Boolean,
+          "serial"          => String,
+          "size"            => Integer,
+          "source"          => Fog::Nullable::String,
+          "source_type"     => String,
+          "storage_type"    => String,
+          "created_at"      => String,
+          "updated_at"      => String,
+          "deleted_at"      => Fog::Nullable::String
+        }
+
         ZONE = {
           "id"              => String,
           "resource_type"   => String,
@@ -706,6 +752,7 @@ class Brightbox
           "snapshots"       => [Brightbox::Compute::Formats::Nested::IMAGE],
           "server_groups"   => [Brightbox::Compute::Formats::Nested::SERVER_GROUP],
           "interfaces"      => [Brightbox::Compute::Formats::Nested::INTERFACE],
+          "volumes"         => [Brightbox::Compute::Formats::Nested::VOLUME],
           "zone"            => Fog::Brightbox::Nullable::Zone,
           "licence_name"    => Fog::Nullable::String,
           "username"        => Fog::Nullable::String,
@@ -763,6 +810,32 @@ class Brightbox
           "inviter"         => Brightbox::Compute::Formats::Nested::USER
         }
 
+        VOLUME = {
+          "id"              => String,
+          "resource_type"   => String,
+          "url"             => String,
+          "status"          => String,
+          "name"            => Fog::Nullable::String,
+          "delete_with_server" => Fog::Boolean,
+          "description"     => Fog::Nullable::String,
+          "boot"            => Fog::Boolean,
+          "encrypted"       => Fog::Boolean,
+          "filesystem_label" => Fog::Nullable::String,
+          "filesystem_type" => Fog::Nullable::String,
+          "locked"          => Fog::Boolean,
+          "serial"          => String,
+          "size"            => Integer,
+          "source"          => Fog::Nullable::String,
+          "source_type"     => String,
+          "storage_type"    => String,
+          "created_at"      => String,
+          "updated_at"      => String,
+          "deleted_at"      => Fog::Nullable::String,
+          "account"         => Brightbox::Compute::Formats::Nested::ACCOUNT,
+          "image"           => Fog::Brightbox::Nullable::Image,
+          "server"          => Fog::Brightbox::Nullable::Server
+        }
+
         ZONE = {
           "id"              => String,
           "resource_type"   => String,
@@ -787,6 +860,7 @@ class Brightbox
         SERVER_GROUPS = [Brightbox::Compute::Formats::Collected::SERVER_GROUP]
         SERVER_TYPES = [Brightbox::Compute::Formats::Collected::SERVER_TYPE]
         USERS = [Brightbox::Compute::Formats::Collected::USER]
+        VOLUMES = [Brightbox::Compute::Formats::Collected::VOLUME]
         ZONES = [Brightbox::Compute::Formats::Collected::ZONE]
       end
     end

--- a/tests/brightbox/requests/compute/volume_tests.rb
+++ b/tests/brightbox/requests/compute/volume_tests.rb
@@ -1,0 +1,57 @@
+Shindo.tests("Fog::Compute[:brightbox] | volume requests", ["brightbox"]) do
+  pending if Fog.mocking?
+  image_id = Brightbox::Compute::TestSupport.image_id
+
+  tests("success") do
+    create_options = { image: image_id }
+
+    tests("#create_volume(#{create_options.inspect})") do
+      result = Fog::Compute[:brightbox].create_volume(create_options)
+      @volume_id = result["id"]
+      data_matches_schema(Brightbox::Compute::Formats::Full::VOLUME, :allow_extra_keys => true) { result }
+    end
+
+    tests("#list_volumes") do
+      result = Fog::Compute[:brightbox].list_volumes
+      data_matches_schema(Brightbox::Compute::Formats::Collection::VOLUMES, :allow_extra_keys => true) { result }
+
+      test("#{@volume_id} is listed") do
+        result.any? do |volume|
+          volume["id"] == @volume_id
+        end
+      end
+    end
+
+    tests("#get_volume('#{@volume_id}')") do
+      result = Fog::Compute[:brightbox].get_volume(@volume_id)
+      data_matches_schema(Brightbox::Compute::Formats::Full::VOLUME, :allow_extra_keys => true) { result }
+    end
+
+    update_options = {
+      name: "New name"
+    }
+    tests("#update_volume('#{@volume_id}', ...)") do
+      result = Fog::Compute[:brightbox].update_volume(@volume_id, update_options)
+      data_matches_schema(Brightbox::Compute::Formats::Full::VOLUME, :allow_extra_keys => true) { result }
+
+      test("name has updated") { result["name"] == "New name" }
+    end
+
+    Fog::Compute[:brightbox].volumes.get(@volume_id).wait_for { ready? }
+
+    tests("#delete_volume('#{@volume_id}')") do
+      result = Fog::Compute[:brightbox].delete_volume(@volume_id)
+      data_matches_schema(Brightbox::Compute::Formats::Full::VOLUME, :allow_extra_keys => true) { result }
+    end
+  end
+
+  tests("failure") do
+    tests("create_volume without options").raises(ArgumentError) do
+      Fog::Compute[:brightbox].create_volume
+    end
+
+    tests("get_volume with invalid ID").raises(Excon::Errors::NotFound) do
+      Fog::Compute[:brightbox].get_volume("vol-00000")
+    end
+  end
+end


### PR DESCRIPTION
This adds support to `fog` for dynamic, network attached volumes for
Brightbox servers.

Servers with `nbs` types (Network Block Storage) can be created from a
volume or additional volumes can be attached. Volumes can be quickly
copied and resized.