### PR TITLE
Add opt-in support for Brightbox 2FA

### DIFF
--- a/lib/fog/brightbox/compute.rb
+++ b/lib/fog/brightbox/compute.rb
@@ -21,6 +21,10 @@ module Fog
       # Automatic token management
       recognizes :brightbox_token_management
 
+      # Two Factor Authentication support (2FA)
+      recognizes :brightbox_support_two_factor
+      recognizes :brightbox_one_time_password
+
       # Excon connection settings
       recognizes :persistent
 

--- a/lib/fog/brightbox/config.rb
+++ b/lib/fog/brightbox/config.rb
@@ -33,6 +33,10 @@ module Fog
       #   Set to specify the client secret to use for requests.
       # @option options [String] :brightbox_token_management (true)
       #   Set to specify if the service should handle expired tokens or raise an error instead.
+      # @option options [Boolean] :brightbox_support_two_factor
+      #   Set to enable two factor authentication (2FA) for this configuration/user
+      # @option options [String] :brightbox_one_time_password
+      #   Set to pass through the current one time password when using 2FA
       # @option options [String] :brightbox_username
       #   Set to specify your user account. Either user identifier (+usr-12345+) or email address
       #   may be used.
@@ -225,6 +229,14 @@ module Fog
 
       def storage_temp_key
         @options[:brightbox_temp_url_key]
+      end
+
+      def two_factor?
+        @options[:brightbox_support_two_factor] || false
+      end
+
+      def one_time_password
+        @options[:brightbox_one_time_password]
       end
     end
   end

--- a/spec/fog/brightbox/compute/credentials_spec.rb
+++ b/spec/fog/brightbox/compute/credentials_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+describe Fog::Brightbox::Compute, "#credentials" do
+  describe "when 2FA support is disabled" do
+    before do
+      @options = {
+        brightbox_client_id: "app-12345",
+        brightbox_secret: "1234567890",
+        brightbox_username: "jason.null@brightbox.com",
+        brightbox_password: "HR4life",
+        brightbox_one_time_password: "123456"
+      }
+      @service = Fog::Brightbox::Compute.new(@options)
+    end
+
+    it "does not add passed OTP to credentials" do
+      assert_kind_of Fog::Brightbox::OAuth2::CredentialSet, @service.credentials
+      assert_nil @service.credentials.one_time_password
+    end
+  end
+
+  describe "with 2FA support is enabled" do
+    before do
+      @expected_otp = "123456"
+      @options = {
+        brightbox_client_id: "app-12345",
+        brightbox_secret: "1234567890",
+        brightbox_username: "jason.null@brightbox.com",
+        brightbox_password: "HR4life",
+        brightbox_support_two_factor: true,
+        brightbox_one_time_password: @expected_otp
+      }
+      @service = Fog::Brightbox::Compute.new(@options)
+    end
+
+    it "adds passed OTP to credentials" do
+      assert_kind_of Fog::Brightbox::OAuth2::CredentialSet, @service.credentials
+      assert @expected_otp, @service.credentials.one_time_password
+    end
+  end
+end

--- a/spec/fog/brightbox/compute/get_access_token_spec.rb
+++ b/spec/fog/brightbox/compute/get_access_token_spec.rb
@@ -1,0 +1,231 @@
+require "spec_helper"
+
+describe Fog::Brightbox::Compute, "#get_access_token" do
+  before do
+    @new_access_token = "0987654321"
+    @new_refresh_token = "5432167890"
+
+    @options = {
+      brightbox_client_id: "app-12345",
+      brightbox_secret: "1234567890",
+      brightbox_username: "jason.null@brightbox.com",
+      brightbox_password: "HR4life"
+    }
+    @service = Fog::Brightbox::Compute.new(@options)
+  end
+
+  describe "when user does not have 2FA enabled" do
+    describe "and authenticates correctly" do
+      before do
+        stub_authentication_request(auth_correct: true)
+      end
+
+      describe "without !" do
+        it "updates credentials" do
+          token = @service.get_access_token
+          assert_equal "0987654321", token
+
+          assert_equal token, @service.access_token
+        end
+      end
+
+      describe "with !" do
+        it "updates credentials" do
+          token = @service.get_access_token!
+          assert_equal "0987654321", token
+
+          assert_equal token, @service.access_token
+        end
+      end
+    end
+
+    describe "and authenticates incorrectly" do
+      before do
+        stub_authentication_request(auth_correct: false)
+      end
+
+      describe "without !" do
+        it "returns nil" do
+          assert_nil @service.get_access_token
+
+          assert_nil @service.access_token
+          assert_nil @service.refresh_token
+        end
+      end
+
+      describe "with !" do
+        it "raises an error" do
+          begin
+            @service.get_access_token!
+          rescue Excon::Error::Unauthorized
+            assert_nil @service.access_token
+            assert_nil @service.refresh_token
+          end
+        end
+      end
+    end
+  end
+
+  describe "when user does have 2FA enabled" do
+    describe "and authenticates correctly" do
+      describe "without OTP" do
+        before do
+          stub_authentication_request(auth_correct: true,
+                                      two_factor_user: true)
+        end
+
+        describe "without !" do
+          it "returns nil" do
+            assert_nil @service.get_access_token
+
+            assert_nil @service.access_token
+            assert_nil @service.refresh_token
+          end
+        end
+
+        describe "with !" do
+          it "raises an error" do
+            begin
+              @service.get_access_token!
+            rescue Excon::Error::Unauthorized
+              assert_nil @service.access_token
+              assert_nil @service.refresh_token
+            end
+          end
+        end
+      end
+
+      describe "with OTP" do
+        before do
+          skip "Requires implementation"
+
+          stub_authentication_request(auth_correct: true,
+                                      two_factor_user: true,
+                                      otp_sent: true)
+        end
+
+        describe "without !" do
+          it "returns nil" do
+            assert_nil @service.get_access_token
+
+            assert_nil @service.access_token
+            assert_nil @service.refresh_token
+          end
+        end
+
+        describe "with !" do
+          it "raises an error" do
+            begin
+              @service.get_access_token!
+            rescue Excon::Error::Unauthorized
+              assert_nil @service.access_token
+              assert_nil @service.refresh_token
+            end
+          end
+        end
+      end
+    end
+
+    describe "and authenticates incorrectly" do
+      before do
+        stub_authentication_request(auth_correct: false,
+                                    two_factor_user: true)
+      end
+
+      describe "without !" do
+        it "returns nil" do
+          assert_nil @service.get_access_token
+
+          assert_nil @service.access_token
+          assert_nil @service.refresh_token
+        end
+      end
+
+      describe "with !" do
+        it "raises an error" do
+          begin
+            @service.get_access_token!
+          rescue Excon::Error::Unauthorized
+            assert_nil @service.access_token
+            assert_nil @service.refresh_token
+          end
+        end
+      end
+    end
+
+    describe "without 2FA support enabled" do
+      it do
+        stub_authentication_request(auth_correct: false,
+                                    two_factor_user: true)
+
+        assert_nil @service.get_access_token
+
+        assert_nil @service.access_token
+        assert_nil @service.refresh_token
+      end
+    end
+  end
+
+  # @param auth_correct [Boolean] Treat username/password as correct
+  # @param two_factor_user [Boolean] Is user protected by 2FA on server
+  # @param otp_sent [Boolean] The OTP code
+  def stub_authentication_request(auth_correct:,
+                                  two_factor_user: false,
+                                  otp_sent: nil)
+    request = {
+      headers: {
+        "Authorization" => "Basic YXBwLTEyMzQ1OjEyMzQ1Njc4OTA=",
+        "Content-Type" => "application/json",
+      },
+      body: {
+        grant_type: "password",
+        username: "jason.null@brightbox.com",
+        password: "HR4life"
+      }.to_json
+    }.tap do |req|
+      if otp_sent
+        req[:headers]["X-Brightbox-OTP"] = "123456"
+      end
+    end
+
+    # The cases we are testing are:
+    #
+    # * User does not use 2FA and authenticate
+    # * User does not use 2FA and FAILS to authenticate
+    # * User does use 2FA and authenticate
+    # * User does use 2FA and FAILS to authenticate
+    # * User does use 2FA and FAILS to send OTP
+    #
+    response = if two_factor_user && !otp_sent
+      # OTP required header
+      {
+        status: 401,
+        headers: {
+          "X-Brightbox-OTP" => "required"
+        },
+        body: { error: "invalid_client" }.to_json
+      }
+    elsif !auth_correct
+      # No OTP header
+      {
+        status: 401,
+        headers: {},
+        body: { error: "invalid_client" }.to_json
+      }
+    else
+      {
+        status: 200,
+        headers: {},
+        body: {
+          access_token: @new_access_token,
+          refresh_token: @new_refresh_token,
+          expires_in: 7200
+        }.to_json
+      }
+    end
+
+    stub_request(:post, "https://api.gb1.brightbox.com/token")
+      .with(request)
+      .to_return(response)
+  end
+end

--- a/spec/fog/brightbox/compute/two_factor_spec.rb
+++ b/spec/fog/brightbox/compute/two_factor_spec.rb
@@ -1,0 +1,53 @@
+require "spec_helper"
+
+describe Fog::Brightbox::Compute, "#two_factor?" do
+  describe "when omitted" do
+    before do
+      @options = {
+        brightbox_client_id: "app-12345",
+        brightbox_secret: "1234567890",
+        brightbox_username: "jason.null@brightbox.com",
+        brightbox_password: "HR4life"
+      }
+      @service = Fog::Brightbox::Compute.new(@options)
+    end
+
+    it do
+      refute @service.two_factor?
+    end
+  end
+
+  describe "when disabled" do
+    before do
+      @options = {
+        brightbox_client_id: "app-12345",
+        brightbox_secret: "1234567890",
+        brightbox_username: "jason.null@brightbox.com",
+        brightbox_password: "HR4life",
+        brightbox_support_two_factor: false
+      }
+      @service = Fog::Brightbox::Compute.new(@options)
+    end
+
+    it do
+      refute @service.two_factor?
+    end
+  end
+
+  describe "when enabled" do
+    before do
+      @options = {
+        brightbox_client_id: "app-12345",
+        brightbox_secret: "1234567890",
+        brightbox_username: "jason.null@brightbox.com",
+        brightbox_password: "HR4life",
+        brightbox_support_two_factor: true
+      }
+      @service = Fog::Brightbox::Compute.new(@options)
+    end
+
+    it do
+      assert @service.two_factor?
+    end
+  end
+end

--- a/spec/fog/brightbox/oauth2/user_credentials_strategy_spec.rb
+++ b/spec/fog/brightbox/oauth2/user_credentials_strategy_spec.rb
@@ -37,4 +37,24 @@ describe Fog::Brightbox::OAuth2::UserCredentialsStrategy do
     assert_equal "Basic YXBwLTEyMzQ1Ol9fbWFzaGVkX2tleXNfMTIzX18=", headers["Authorization"]
     assert_equal "application/json", headers["Content-Type"]
   end
+
+  describe "when 2FA OTP is included" do
+    before do
+      options = {
+        username: @username,
+        password: @password,
+        one_time_password: "123456"
+      }
+
+      @credentials = Fog::Brightbox::OAuth2::CredentialSet.new(@client_id, @client_secret, options)
+      @strategy = Fog::Brightbox::OAuth2::UserCredentialsStrategy.new(@credentials)
+    end
+
+    it "tests #headers" do
+      headers = @strategy.headers
+      assert_equal "Basic YXBwLTEyMzQ1Ol9fbWFzaGVkX2tleXNfMTIzX18=", headers["Authorization"]
+      assert_equal "application/json", headers["Content-Type"]
+      assert_equal "123456", headers["X-Brightbox-OTP"]
+    end
+  end
 end


### PR DESCRIPTION
This adds a new *opt-in* way to support Brightbox 2FA within clients.

Passing `brightbox_support_two_factor` into a configuration will raise a new error when user authentication has failed BUT the presence of the `X-Brightbox-OTP: required` HTTP header is found.

This new error `Fog::Brightbox::OAuth2::TwoFactorMissingError` can be handled differently by the client and the second factor can be prompted for or recovered from a secure keychain.

Without opting in, the previous error `Excon::Errors::Unauthorized` is raised.

To send the OTP, the `brightbox_one_time_password` can be passed into a configuration object or `one_time_password` can be passed to a credentials object.