### PR TITLE
Update model attributes to match latest API

### DIFF
--- a/lib/fog/brightbox/models/compute/account.rb
+++ b/lib/fog/brightbox/models/compute/account.rb
@@ -20,24 +20,29 @@ module Fog
         attribute :telephone_number
         attribute :verified_telephone
         attribute :verified_ip
-        attribute :servers_used
-        attribute :ram_limit
-        attribute :ram_used
-        attribute :cloud_ips_limit
-        attribute :cloud_ips_used
-        attribute :load_balancers_limit
-        attribute :load_balancers_used
-        attribute :dbs_servers_used
-        attribute :dbs_ram_limit
-        attribute :dbs_ram_used
+
+        # Account limits (read-only)
+        attribute :block_storage_limit, type: :integer
+        attribute :block_storage_used, type: :integer
+        attribute :cloud_ips_limit, type: :integer
+        attribute :cloud_ips_used, type: :integer
+        attribute :dbs_instances_used, type: :integer
+        attribute :dbs_ram_limit, type: :integer
+        attribute :dbs_ram_used, type: :integer
+        attribute :load_balancers_limit, type: :integer
+        attribute :load_balancers_used, type: :integer
+        attribute :ram_limit, type: :integer
+        attribute :ram_used, type: :integer
+        attribute :servers_used, type: :integer
+
         attribute :library_ftp_host
         attribute :library_ftp_user
         # This is always returned as nil unless after a call to reset_ftp_password
         attribute :library_ftp_password
 
         # Boolean flags
-        attribute :valid_credit_card
-        attribute :telephone_verified
+        attribute :valid_credit_card, type: :boolean
+        attribute :telephone_verified, type: :boolean
 
         # Timestamps
         attribute :created_at, type: :time
@@ -46,9 +51,16 @@ module Fog
         # Links
         attribute :owner_id, aliases: "owner", squash: "id"
         attribute :clients
+        attribute :cloud_ips
+        attribute :database_servers
+        attribute :database_snapshots
+        attribute :firewall_policies
         attribute :images
+        attribute :load_balancers
+        attribute :server_groups
         attribute :servers
         attribute :users
+        attribute :volumes
         attribute :zones
 
         # Resets the account's image library FTP password returning the new value

--- a/lib/fog/brightbox/models/compute/account.rb
+++ b/lib/fog/brightbox/models/compute/account.rb
@@ -40,11 +40,11 @@ module Fog
         attribute :telephone_verified
 
         # Times
-        attribute :created_at, :type => :time
-        attribute :verified_at, :type => :time
+        attribute :created_at, type: :time
+        attribute :verified_at, type: :time
 
         # Links - to be replaced
-        attribute :owner_id, :aliases => "owner", :squash => "id"
+        attribute :owner_id, aliases: "owner", squash: "id"
         attribute :clients
         attribute :images
         attribute :servers

--- a/lib/fog/brightbox/models/compute/account.rb
+++ b/lib/fog/brightbox/models/compute/account.rb
@@ -39,11 +39,11 @@ module Fog
         attribute :valid_credit_card
         attribute :telephone_verified
 
-        # Times
+        # Timestamps
         attribute :created_at, type: :time
         attribute :verified_at, type: :time
 
-        # Links - to be replaced
+        # Links
         attribute :owner_id, aliases: "owner", squash: "id"
         attribute :clients
         attribute :images

--- a/lib/fog/brightbox/models/compute/account.rb
+++ b/lib/fog/brightbox/models/compute/account.rb
@@ -3,8 +3,8 @@ module Fog
     class Compute
       class Account < Fog::Brightbox::Model
         identity :id
-        attribute :url
         attribute :resource_type
+        attribute :url
 
         attribute :name
         attribute :status

--- a/lib/fog/brightbox/models/compute/api_client.rb
+++ b/lib/fog/brightbox/models/compute/api_client.rb
@@ -8,14 +8,15 @@ module Fog
 
         attribute :name
         attribute :description
-        attribute :permissions_group
+
         attribute :secret
+        attribute :permissions_group
 
         # Timestamps
         attribute :revoked_at, type: :time
 
         # Links
-        attribute :account_id
+        attribute :account_id, aliases: "account", squash: "id"
 
         def save
           raise Fog::Errors::Error.new("Resaving an existing object may create a duplicate") if persisted?

--- a/lib/fog/brightbox/models/compute/api_client.rb
+++ b/lib/fog/brightbox/models/compute/api_client.rb
@@ -8,9 +8,13 @@ module Fog
 
         attribute :name
         attribute :description
-        attribute :secret
-        attribute :revoked_at, type: :time
         attribute :permissions_group
+        attribute :secret
+
+        # Timestamps
+        attribute :revoked_at, type: :time
+
+        # Links
         attribute :account_id
 
         def save

--- a/lib/fog/brightbox/models/compute/api_client.rb
+++ b/lib/fog/brightbox/models/compute/api_client.rb
@@ -9,7 +9,7 @@ module Fog
         attribute :name
         attribute :description
         attribute :secret
-        attribute :revoked_at, :type => :time
+        attribute :revoked_at, type: :time
         attribute :permissions_group
         attribute :account_id
 

--- a/lib/fog/brightbox/models/compute/api_client.rb
+++ b/lib/fog/brightbox/models/compute/api_client.rb
@@ -3,6 +3,9 @@ module Fog
     class Compute
       class ApiClient < Fog::Brightbox::Model
         identity :id
+        attribute :resource_type
+        attribute :url
+
         attribute :name
         attribute :description
         attribute :secret

--- a/lib/fog/brightbox/models/compute/application.rb
+++ b/lib/fog/brightbox/models/compute/application.rb
@@ -3,7 +3,9 @@ module Fog
     class Compute
       class Application < Fog::Brightbox::Model
         identity :id
+        attribute :resource_type
         attribute :url
+
         attribute :name
         attribute :secret
 

--- a/lib/fog/brightbox/models/compute/application.rb
+++ b/lib/fog/brightbox/models/compute/application.rb
@@ -7,7 +7,13 @@ module Fog
         attribute :url
 
         attribute :name
+        attribute :description
         attribute :secret
+
+        # Timestamps
+        attribute :created_at, type: :time
+        attribute :updated_at, type: :time
+        attribute :revoked_at, type: :time
 
         def save
           raise Fog::Errors::Error.new("Resaving an existing object may create a duplicate") if persisted?

--- a/lib/fog/brightbox/models/compute/cloud_ip.rb
+++ b/lib/fog/brightbox/models/compute/cloud_ip.rb
@@ -24,7 +24,6 @@ module Fog
         attribute :server_group, :alias => "server_group", :squash => "id"
         attribute :database_server, :alias => "database_server", :squash => "id"
         attribute :port_translators
-        attribute :name
 
         # Attempt to map or point the Cloud IP to the destination resource.
         #

--- a/lib/fog/brightbox/models/compute/cloud_ip.rb
+++ b/lib/fog/brightbox/models/compute/cloud_ip.rb
@@ -3,8 +3,8 @@ module Fog
     class Compute
       class CloudIp < Fog::Brightbox::Model
         identity :id
-        attribute :url
         attribute :resource_type
+        attribute :url
 
         attribute :name
         attribute :status

--- a/lib/fog/brightbox/models/compute/cloud_ip.rb
+++ b/lib/fog/brightbox/models/compute/cloud_ip.rb
@@ -16,7 +16,7 @@ module Fog
         attribute :public_ipv6
         attribute :fqdn
 
-        # Links - to be replaced
+        # Links
         attribute :account_id, aliases: "account", squash: "id"
         attribute :interface_id, aliases: "interface", squash: "id"
         attribute :server_id, aliases: "server", squash: "id"

--- a/lib/fog/brightbox/models/compute/cloud_ip.rb
+++ b/lib/fog/brightbox/models/compute/cloud_ip.rb
@@ -10,11 +10,12 @@ module Fog
         attribute :status
         attribute :description
 
-        attribute :reverse_dns
+        attribute :fqdn
+        attribute :mode
         attribute :public_ip
         attribute :public_ipv4
         attribute :public_ipv6
-        attribute :fqdn
+        attribute :reverse_dns
 
         # Links
         attribute :account_id, aliases: "account", squash: "id"

--- a/lib/fog/brightbox/models/compute/cloud_ip.rb
+++ b/lib/fog/brightbox/models/compute/cloud_ip.rb
@@ -17,12 +17,12 @@ module Fog
         attribute :fqdn
 
         # Links - to be replaced
-        attribute :account_id, :aliases => "account", :squash => "id"
-        attribute :interface_id, :aliases => "interface", :squash => "id"
-        attribute :server_id, :aliases => "server", :squash => "id"
-        attribute :load_balancer, :alias => "load_balancer", :squash => "id"
-        attribute :server_group, :alias => "server_group", :squash => "id"
-        attribute :database_server, :alias => "database_server", :squash => "id"
+        attribute :account_id, aliases: "account", squash: "id"
+        attribute :interface_id, aliases: "interface", squash: "id"
+        attribute :server_id, aliases: "server", squash: "id"
+        attribute :load_balancer, :alias => "load_balancer", squash: "id"
+        attribute :server_group, :alias => "server_group", squash: "id"
+        attribute :database_server, :alias => "database_server", squash: "id"
         attribute :port_translators
 
         # Attempt to map or point the Cloud IP to the destination resource.

--- a/lib/fog/brightbox/models/compute/collaboration.rb
+++ b/lib/fog/brightbox/models/compute/collaboration.rb
@@ -3,6 +3,9 @@ module Fog
     class Compute
       class Collaboration < Fog::Brightbox::Model
         identity :id
+        attribute :resource_type
+        attribute :url
+
         attribute :status
         attribute :email
         attribute :role

--- a/lib/fog/brightbox/models/compute/collaboration.rb
+++ b/lib/fog/brightbox/models/compute/collaboration.rb
@@ -7,9 +7,17 @@ module Fog
         attribute :url
 
         attribute :status
+
         attribute :email
         attribute :role
         attribute :role_label
+
+        # Timestamps
+        attribute :created_at, type: :time
+        attribute :started_at, type: :time
+        attribute :finished_at, type: :time
+
+        # Links
         attribute :account
         attribute :user
         attribute :inviter

--- a/lib/fog/brightbox/models/compute/database_server.rb
+++ b/lib/fog/brightbox/models/compute/database_server.rb
@@ -10,7 +10,7 @@ module Fog
 
         attribute :name
         attribute :description
-        attribute :state, :aliases => "status"
+        attribute :state, aliases: "status"
 
         attribute :admin_username
         attribute :admin_password
@@ -22,17 +22,17 @@ module Fog
         attribute :maintenance_hour
 
         # This is a crontab formatted string e.g. "* 5 * * 0"
-        attribute :snapshots_schedule, :type => :string
-        attribute :snapshots_schedule_next_at, :type => :time
+        attribute :snapshots_schedule, type: :string
+        attribute :snapshots_schedule_next_at, type: :time
 
-        attribute :created_at, :type => :time
-        attribute :updated_at, :type => :time
-        attribute :deleted_at, :type => :time
+        attribute :created_at, type: :time
+        attribute :updated_at, type: :time
+        attribute :deleted_at, type: :time
 
         attribute :allow_access
 
-        attribute :flavor_id, "alias" => "database_server_type", :squash => "id"
-        attribute :zone_id, "alias" => "zone", :squash => "id"
+        attribute :flavor_id, "alias" => "database_server_type", squash: "id"
+        attribute :zone_id, "alias" => "zone", squash: "id"
 
         attribute :snapshot_id
 

--- a/lib/fog/brightbox/models/compute/database_server.rb
+++ b/lib/fog/brightbox/models/compute/database_server.rb
@@ -14,14 +14,14 @@ module Fog
 
         attribute :admin_username
         attribute :admin_password
-
         attribute :allow_access
-
         attribute :database_engine
         attribute :database_version
+        attribute :maintenance_hour #, type: :integer
+        attribute :maintenance_weekday #, type: :integer
+        attribute :source
 
-        attribute :maintenance_weekday
-        attribute :maintenance_hour
+        attribute :snapshots_retention, type: :string
 
         # This is a crontab formatted string e.g. "* 5 * * 0"
         attribute :snapshots_schedule, type: :string
@@ -33,12 +33,14 @@ module Fog
         attribute :deleted_at, type: :time
 
         # Links
-        attribute :flavor_id, "alias" => "database_server_type", squash: "id"
-        attribute :zone_id, "alias" => "zone", squash: "id"
+        attribute :flavor_id, alias: "database_server_type", squash: "id"
+        attribute :zone_id, alias: "zone", squash: "id"
 
-        attribute :snapshot_id
-
+        attribute :account
         attribute :cloud_ips
+
+        # Generated from snapshot action and not a real attribute
+        attribute :snapshot_id
 
         def save
           options = {

--- a/lib/fog/brightbox/models/compute/database_server.rb
+++ b/lib/fog/brightbox/models/compute/database_server.rb
@@ -15,6 +15,8 @@ module Fog
         attribute :admin_username
         attribute :admin_password
 
+        attribute :allow_access
+
         attribute :database_engine
         attribute :database_version
 
@@ -25,12 +27,12 @@ module Fog
         attribute :snapshots_schedule, type: :string
         attribute :snapshots_schedule_next_at, type: :time
 
+        # Timestamps
         attribute :created_at, type: :time
         attribute :updated_at, type: :time
         attribute :deleted_at, type: :time
 
-        attribute :allow_access
-
+        # Links
         attribute :flavor_id, "alias" => "database_server_type", squash: "id"
         attribute :zone_id, "alias" => "zone", squash: "id"
 

--- a/lib/fog/brightbox/models/compute/database_server.rb
+++ b/lib/fog/brightbox/models/compute/database_server.rb
@@ -5,8 +5,8 @@ module Fog
         include Fog::Brightbox::Compute::ResourceLocking
 
         identity :id
-        attribute :url
         attribute :resource_type
+        attribute :url
 
         attribute :name
         attribute :description

--- a/lib/fog/brightbox/models/compute/database_snapshot.rb
+++ b/lib/fog/brightbox/models/compute/database_snapshot.rb
@@ -7,8 +7,8 @@ module Fog
         include Fog::Brightbox::Compute::ResourceLocking
 
         identity :id
-        attribute :url
         attribute :resource_type
+        attribute :url
 
         attribute :name
         attribute :description

--- a/lib/fog/brightbox/models/compute/database_snapshot.rb
+++ b/lib/fog/brightbox/models/compute/database_snapshot.rb
@@ -12,16 +12,16 @@ module Fog
 
         attribute :name
         attribute :description
-        attribute :state, :aliases => "status"
+        attribute :state, aliases: "status"
 
         attribute :database_engine
         attribute :database_version
 
         attribute :size
 
-        attribute :created_at, :type => :time
-        attribute :updated_at, :type => :time
-        attribute :deleted_at, :type => :time
+        attribute :created_at, type: :time
+        attribute :updated_at, type: :time
+        attribute :deleted_at, type: :time
 
         def save
           options = {

--- a/lib/fog/brightbox/models/compute/database_snapshot.rb
+++ b/lib/fog/brightbox/models/compute/database_snapshot.rb
@@ -17,12 +17,18 @@ module Fog
         attribute :database_engine
         attribute :database_version
 
-        attribute :size
+        attribute :size, type: :integer
+        attribute :source
+        attribute :source_trigger
 
         # Timestamps
         attribute :created_at, type: :time
         attribute :updated_at, type: :time
         attribute :deleted_at, type: :time
+
+        # Links
+        attribute :account
+        attribute :account_id, aliases: "account", squash: "id"
 
         def save
           options = {

--- a/lib/fog/brightbox/models/compute/database_snapshot.rb
+++ b/lib/fog/brightbox/models/compute/database_snapshot.rb
@@ -19,6 +19,7 @@ module Fog
 
         attribute :size
 
+        # Timestamps
         attribute :created_at, type: :time
         attribute :updated_at, type: :time
         attribute :deleted_at, type: :time

--- a/lib/fog/brightbox/models/compute/database_type.rb
+++ b/lib/fog/brightbox/models/compute/database_type.rb
@@ -3,8 +3,8 @@ module Fog
     class Compute
       class DatabaseType < Fog::Brightbox::Model
         identity :id
-        attribute :url
         attribute :resource_type
+        attribute :url
 
         attribute :name
         attribute :description

--- a/lib/fog/brightbox/models/compute/database_type.rb
+++ b/lib/fog/brightbox/models/compute/database_type.rb
@@ -9,8 +9,11 @@ module Fog
         attribute :name
         attribute :description
 
-        attribute :disk, aliases: "disk_size"
-        attribute :ram
+        attribute :disk, aliases: "disk_size", type: :integer
+        attribute :ram, type: :integer
+
+        # Boolean flags
+        attribute :default, type: :boolean
       end
     end
   end

--- a/lib/fog/brightbox/models/compute/database_type.rb
+++ b/lib/fog/brightbox/models/compute/database_type.rb
@@ -9,7 +9,7 @@ module Fog
         attribute :name
         attribute :description
 
-        attribute :disk, :aliases => "disk_size"
+        attribute :disk, aliases: "disk_size"
         attribute :ram
       end
     end

--- a/lib/fog/brightbox/models/compute/event.rb
+++ b/lib/fog/brightbox/models/compute/event.rb
@@ -15,6 +15,7 @@ module Fog
         attribute :created_at, type: :time
 
         # Links
+        attribute :affects
         attribute :resource
         attribute :client
         attribute :user

--- a/lib/fog/brightbox/models/compute/event.rb
+++ b/lib/fog/brightbox/models/compute/event.rb
@@ -4,8 +4,8 @@ module Fog
       # @api private
       class Event < Fog::Brightbox::Model
         identity :id
-        attribute :url
         attribute :resource_type
+        attribute :url
 
         attribute :action
         attribute :message

--- a/lib/fog/brightbox/models/compute/event.rb
+++ b/lib/fog/brightbox/models/compute/event.rb
@@ -11,10 +11,10 @@ module Fog
         attribute :message
         attribute :short_message
 
-        # Times
+        # Timestamps
         attribute :created_at, type: :time
 
-        # Links - to be replaced
+        # Links
         attribute :resource
         attribute :client
         attribute :user

--- a/lib/fog/brightbox/models/compute/event.rb
+++ b/lib/fog/brightbox/models/compute/event.rb
@@ -12,7 +12,7 @@ module Fog
         attribute :short_message
 
         # Times
-        attribute :created_at, :type => :time
+        attribute :created_at, type: :time
 
         # Links - to be replaced
         attribute :resource

--- a/lib/fog/brightbox/models/compute/firewall_policy.rb
+++ b/lib/fog/brightbox/models/compute/firewall_policy.rb
@@ -3,8 +3,8 @@ module Fog
     class Compute
       class FirewallPolicy < Fog::Brightbox::Model
         identity :id
-        attribute :url
         attribute :resource_type
+        attribute :url
 
         attribute :name
         attribute :description

--- a/lib/fog/brightbox/models/compute/firewall_policy.rb
+++ b/lib/fog/brightbox/models/compute/firewall_policy.rb
@@ -11,8 +11,8 @@ module Fog
 
         attribute :default
 
-        attribute :server_group_id, :aliases => "server_group", :squash => "id"
-        attribute :created_at, :type => :time
+        attribute :server_group_id, aliases: "server_group", squash: "id"
+        attribute :created_at, type: :time
         attribute :rules
 
         # Sticking with existing Fog behaviour, save does not update but creates a new resource

--- a/lib/fog/brightbox/models/compute/firewall_policy.rb
+++ b/lib/fog/brightbox/models/compute/firewall_policy.rb
@@ -10,13 +10,15 @@ module Fog
         attribute :description
 
         # Boolean flags
-        attribute :default
+        attribute :default, type: :boolean
 
         # Timestamps
         attribute :created_at, type: :time
 
         # Links
+        attribute :account_id, aliases: "account", squash: "id"
         attribute :server_group_id, aliases: "server_group", squash: "id"
+
         attribute :rules
 
         # Sticking with existing Fog behaviour, save does not update but creates a new resource

--- a/lib/fog/brightbox/models/compute/firewall_policy.rb
+++ b/lib/fog/brightbox/models/compute/firewall_policy.rb
@@ -9,10 +9,14 @@ module Fog
         attribute :name
         attribute :description
 
+        # Boolean flags
         attribute :default
 
-        attribute :server_group_id, aliases: "server_group", squash: "id"
+        # Timestamps
         attribute :created_at, type: :time
+
+        # Links
+        attribute :server_group_id, aliases: "server_group", squash: "id"
         attribute :rules
 
         # Sticking with existing Fog behaviour, save does not update but creates a new resource

--- a/lib/fog/brightbox/models/compute/firewall_rule.rb
+++ b/lib/fog/brightbox/models/compute/firewall_rule.rb
@@ -14,9 +14,9 @@ module Fog
         attribute :destination_port
         attribute :protocol
         attribute :icmp_type_name
-        attribute :created_at, :type => :time
+        attribute :created_at, type: :time
 
-        attribute :firewall_policy_id, :aliases => "firewall_policy", :squash => "id"
+        attribute :firewall_policy_id, aliases: "firewall_policy", squash: "id"
 
         # Sticking with existing Fog behaviour, save does not update but creates a new resource
         def save

--- a/lib/fog/brightbox/models/compute/firewall_rule.rb
+++ b/lib/fog/brightbox/models/compute/firewall_rule.rb
@@ -8,12 +8,12 @@ module Fog
 
         attribute :description
 
-        attribute :source
-        attribute :source_port
         attribute :destination
         attribute :destination_port
-        attribute :protocol
         attribute :icmp_type_name
+        attribute :protocol
+        attribute :source
+        attribute :source_port
 
         # Timestamps
         attribute :created_at, type: :time

--- a/lib/fog/brightbox/models/compute/firewall_rule.rb
+++ b/lib/fog/brightbox/models/compute/firewall_rule.rb
@@ -14,8 +14,11 @@ module Fog
         attribute :destination_port
         attribute :protocol
         attribute :icmp_type_name
+
+        # Timestamps
         attribute :created_at, type: :time
 
+        # Links
         attribute :firewall_policy_id, aliases: "firewall_policy", squash: "id"
 
         # Sticking with existing Fog behaviour, save does not update but creates a new resource

--- a/lib/fog/brightbox/models/compute/firewall_rule.rb
+++ b/lib/fog/brightbox/models/compute/firewall_rule.rb
@@ -3,8 +3,8 @@ module Fog
     class Compute
       class FirewallRule < Fog::Brightbox::Model
         identity :id
-        attribute :url
         attribute :resource_type
+        attribute :url
 
         attribute :description
 

--- a/lib/fog/brightbox/models/compute/flavor.rb
+++ b/lib/fog/brightbox/models/compute/flavor.rb
@@ -14,7 +14,7 @@ module Fog
 
         attribute :bits
         attribute :cores
-        attribute :disk, :aliases => "disk_size"
+        attribute :disk, aliases: "disk_size"
         attribute :ram
 
         def bits

--- a/lib/fog/brightbox/models/compute/flavor.rb
+++ b/lib/fog/brightbox/models/compute/flavor.rb
@@ -8,7 +8,6 @@ module Fog
 
         attribute :name
         attribute :status
-        attribute :description
 
         attribute :handle
 
@@ -16,6 +15,7 @@ module Fog
         attribute :cores
         attribute :disk, aliases: "disk_size"
         attribute :ram
+        attribute :storage_type
 
         def bits
           64 # This is actually based on the Image type used. 32bit or 64bit Images are supported

--- a/lib/fog/brightbox/models/compute/flavor.rb
+++ b/lib/fog/brightbox/models/compute/flavor.rb
@@ -3,8 +3,8 @@ module Fog
     class Compute
       class Flavor < Fog::Brightbox::Model
         identity :id
-        attribute :url
         attribute :resource_type
+        attribute :url
 
         attribute :name
         attribute :status

--- a/lib/fog/brightbox/models/compute/image.rb
+++ b/lib/fog/brightbox/models/compute/image.rb
@@ -25,10 +25,10 @@ module Fog
         attribute :official
         attribute :compatibility_mode
 
-        # Times
+        # Timestamps
         attribute :created_at, type: :time
 
-        # Links - to be replaced
+        # Links
         attribute :ancestor_id, aliases: "ancestor", squash: "id"
         attribute :owner_id, aliases: "owner", squash: "id"
 

--- a/lib/fog/brightbox/models/compute/image.rb
+++ b/lib/fog/brightbox/models/compute/image.rb
@@ -26,11 +26,11 @@ module Fog
         attribute :compatibility_mode
 
         # Times
-        attribute :created_at, :type => :time
+        attribute :created_at, type: :time
 
         # Links - to be replaced
-        attribute :ancestor_id, :aliases => "ancestor", :squash => "id"
-        attribute :owner_id, :aliases => "owner", :squash => "id"
+        attribute :ancestor_id, aliases: "ancestor", squash: "id"
+        attribute :owner_id, aliases: "owner", squash: "id"
 
         def ready?
           status == "available"

--- a/lib/fog/brightbox/models/compute/image.rb
+++ b/lib/fog/brightbox/models/compute/image.rb
@@ -5,8 +5,8 @@ module Fog
         include Fog::Brightbox::Compute::ResourceLocking
 
         identity :id
-        attribute :url
         attribute :resource_type
+        attribute :url
 
         attribute :name
         attribute :username

--- a/lib/fog/brightbox/models/compute/image.rb
+++ b/lib/fog/brightbox/models/compute/image.rb
@@ -9,21 +9,23 @@ module Fog
         attribute :url
 
         attribute :name
-        attribute :username
         attribute :status
         attribute :description
 
-        attribute :source
-        attribute :source_type
         attribute :arch
-        attribute :virtual_size
-        attribute :disk_size
+        attribute :disk_size, type: :integer
         attribute :licence_name
+        attribute :min_ram, type: :integer
+        attribute :source
+        attribute :source_trigger
+        attribute :source_type
+        attribute :username
+        attribute :virtual_size, type: :integer
 
         # Boolean flags
-        attribute :public
-        attribute :official
-        attribute :compatibility_mode
+        attribute :compatibility_mode, type: :boolean
+        attribute :official, type: :boolean
+        attribute :public, type: :boolean
 
         # Timestamps
         attribute :created_at, type: :time

--- a/lib/fog/brightbox/models/compute/load_balancer.rb
+++ b/lib/fog/brightbox/models/compute/load_balancer.rb
@@ -35,8 +35,8 @@ module Fog
         attribute :domains
 
         # Times
-        attribute :created_at, :type => :time
-        attribute :deleted_at, :type => :time
+        attribute :created_at, type: :time
+        attribute :deleted_at, type: :time
 
         # Links - to be replaced
         attribute :account

--- a/lib/fog/brightbox/models/compute/load_balancer.rb
+++ b/lib/fog/brightbox/models/compute/load_balancer.rb
@@ -34,11 +34,11 @@ module Fog
         # List of domains for ACME
         attribute :domains
 
-        # Times
+        # Timestamps
         attribute :created_at, type: :time
         attribute :deleted_at, type: :time
 
-        # Links - to be replaced
+        # Links
         attribute :account
         attribute :server
         attribute :cloud_ip

--- a/lib/fog/brightbox/models/compute/load_balancer.rb
+++ b/lib/fog/brightbox/models/compute/load_balancer.rb
@@ -11,7 +11,7 @@ module Fog
         attribute :name
         attribute :status
 
-        attribute :buffer_size
+        attribute :buffer_size, type: :integer
 
         attribute :policy
         attribute :nodes
@@ -34,14 +34,18 @@ module Fog
         # List of domains for ACME
         attribute :domains
 
+        # Booleans
+        attribute :https_redirect, type: :boolean
+
         # Timestamps
         attribute :created_at, type: :time
         attribute :deleted_at, type: :time
 
         # Links
         attribute :account
-        attribute :server
-        attribute :cloud_ip
+
+        attribute :nodes
+        attribute :cloud_ips
 
         def ready?
           status == "active"

--- a/lib/fog/brightbox/models/compute/load_balancer.rb
+++ b/lib/fog/brightbox/models/compute/load_balancer.rb
@@ -5,8 +5,8 @@ module Fog
         include Fog::Brightbox::Compute::ResourceLocking
 
         identity :id
-        attribute :url
         attribute :resource_type
+        attribute :url
 
         attribute :name
         attribute :status

--- a/lib/fog/brightbox/models/compute/server.rb
+++ b/lib/fog/brightbox/models/compute/server.rb
@@ -23,17 +23,18 @@ module Fog
         attribute :fqdn
         attribute :console_token
 
+        # Boolean flags
         attribute :disk_encrypted
 
-        # Times
+        # Timestamps
         attribute :created_at, type: :time
         attribute :started_at, type: :time
         attribute :console_token_expires, type: :time
         attribute :deleted_at, type: :time
 
-        # Links - to be replaced
-        attribute :account_id,  aliases: "account",      squash: "id"
-        attribute :image_id,    aliases: "image",        squash: "id"
+        # Links
+        attribute :account_id, aliases: "account", squash: "id"
+        attribute :image_id, aliases: "image", squash: "id"
 
         attribute :snapshots
         attribute :cloud_ip # Creation option only

--- a/lib/fog/brightbox/models/compute/server.rb
+++ b/lib/fog/brightbox/models/compute/server.rb
@@ -14,7 +14,7 @@ module Fog
         attribute :url
 
         attribute :name
-        attribute :state,       :aliases => "status"
+        attribute :state,       aliases: "status"
 
         attribute :hostname
         attribute :fqdn
@@ -26,14 +26,14 @@ module Fog
         attribute :disk_encrypted
 
         # Times
-        attribute :created_at, :type => :time
-        attribute :started_at, :type => :time
-        attribute :console_token_expires, :type => :time
-        attribute :deleted_at, :type => :time
+        attribute :created_at, type: :time
+        attribute :started_at, type: :time
+        attribute :console_token_expires, type: :time
+        attribute :deleted_at, type: :time
 
         # Links - to be replaced
-        attribute :account_id,  :aliases => "account",      :squash => "id"
-        attribute :image_id,    :aliases => "image",        :squash => "id"
+        attribute :account_id,  aliases: "account",      squash: "id"
+        attribute :image_id,    aliases: "image",        squash: "id"
 
         attribute :snapshots
         attribute :cloud_ip # Creation option only

--- a/lib/fog/brightbox/models/compute/server.rb
+++ b/lib/fog/brightbox/models/compute/server.rb
@@ -14,17 +14,17 @@ module Fog
         attribute :url
 
         attribute :name
-        attribute :state,       aliases: "status"
+        attribute :state, aliases: "status"
 
-        attribute :hostname
-        attribute :fqdn
-        attribute :user_data
+        attribute :console_token
         attribute :console_url
         attribute :fqdn
-        attribute :console_token
+        attribute :hostname
+        attribute :user_data
 
         # Boolean flags
-        attribute :disk_encrypted
+        attribute :compatibility_mode, type: :boolean
+        attribute :disk_encrypted, type: :boolean
 
         # Timestamps
         attribute :created_at, type: :time
@@ -36,14 +36,15 @@ module Fog
         attribute :account_id, aliases: "account", squash: "id"
         attribute :image_id, aliases: "image", squash: "id"
 
-        attribute :snapshots
+        attribute :server_type
+        attribute :zone
         attribute :cloud_ip # Creation option only
+
         attribute :cloud_ips
         attribute :interfaces
         attribute :server_groups
+        attribute :snapshots
         attribute :volumes
-        attribute :zone
-        attribute :server_type
 
         def initialize(attributes = {})
           # Call super first to initialize the service object for our default image

--- a/lib/fog/brightbox/models/compute/server_group.rb
+++ b/lib/fog/brightbox/models/compute/server_group.rb
@@ -11,9 +11,14 @@ module Fog
 
         attribute :name
         attribute :description
+
+        # Boolean flags
         attribute :default
+
+        # Timestamps
         attribute :created_at, type: :time
 
+        # Links
         attribute :server_ids, aliases: "servers"
 
         def save

--- a/lib/fog/brightbox/models/compute/server_group.rb
+++ b/lib/fog/brightbox/models/compute/server_group.rb
@@ -12,9 +12,9 @@ module Fog
         attribute :name
         attribute :description
         attribute :default
-        attribute :created_at, :type => :time
+        attribute :created_at, type: :time
 
-        attribute :server_ids, :aliases => "servers"
+        attribute :server_ids, aliases: "servers"
 
         def save
           options = {

--- a/lib/fog/brightbox/models/compute/server_group.rb
+++ b/lib/fog/brightbox/models/compute/server_group.rb
@@ -6,9 +6,9 @@ module Fog
       # Certain actions can accept a server group and affect all members
       class ServerGroup < Fog::Brightbox::Model
         identity :id
-
-        attribute :url
         attribute :resource_type
+        attribute :url
+
         attribute :name
         attribute :description
         attribute :default

--- a/lib/fog/brightbox/models/compute/server_group.rb
+++ b/lib/fog/brightbox/models/compute/server_group.rb
@@ -11,14 +11,17 @@ module Fog
 
         attribute :name
         attribute :description
+        attribute :fqdn
 
-        # Boolean flags
-        attribute :default
+        # Booleans
+        attribute :default, type: :boolean
 
         # Timestamps
         attribute :created_at, type: :time
 
         # Links
+        attribute :account_id, aliases: "account", squash: "id"
+        attribute :firewall_policy_id, aliases: "firewall_policy", squash: "id"
         attribute :server_ids, aliases: "servers"
 
         def save

--- a/lib/fog/brightbox/models/compute/user.rb
+++ b/lib/fog/brightbox/models/compute/user.rb
@@ -11,12 +11,17 @@ module Fog
         attribute :ssh_key
 
         # Boolean flags
-        attribute :email_verified
-        attribute :messaging_pref
+        attribute :email_verified, type: :boolean
+
+        # Timestamps
+        attribute :created_at, type: :time
 
         # Links
         attribute :account_id, aliases: "default_account", squash: "id"
         attribute :accounts
+
+        # Deprecated
+        attribute :messaging_pref, type: :boolean
 
         def save
           requires :identity

--- a/lib/fog/brightbox/models/compute/user.rb
+++ b/lib/fog/brightbox/models/compute/user.rb
@@ -15,7 +15,7 @@ module Fog
         attribute :messaging_pref
 
         # Links - to be replaced
-        attribute :account_id, :aliases => "default_account", :squash => "id"
+        attribute :account_id, aliases: "default_account", squash: "id"
         attribute :accounts
 
         def save

--- a/lib/fog/brightbox/models/compute/user.rb
+++ b/lib/fog/brightbox/models/compute/user.rb
@@ -14,7 +14,7 @@ module Fog
         attribute :email_verified
         attribute :messaging_pref
 
-        # Links - to be replaced
+        # Links
         attribute :account_id, aliases: "default_account", squash: "id"
         attribute :accounts
 

--- a/lib/fog/brightbox/models/compute/user_collaboration.rb
+++ b/lib/fog/brightbox/models/compute/user_collaboration.rb
@@ -7,9 +7,17 @@ module Fog
         attribute :url
 
         attribute :status
+
         attribute :email
         attribute :role
         attribute :role_label
+
+        # Timestamps
+        attribute :created_at, type: :time
+        attribute :started_at, type: :time
+        attribute :finished_at, type: :time
+
+        # Links
         attribute :account
         attribute :user
         attribute :inviter

--- a/lib/fog/brightbox/models/compute/user_collaboration.rb
+++ b/lib/fog/brightbox/models/compute/user_collaboration.rb
@@ -3,6 +3,9 @@ module Fog
     class Compute
       class UserCollaboration < Fog::Brightbox::Model
         identity :id
+        # resource_type is buggy for this resource
+        attribute :url
+
         attribute :status
         attribute :email
         attribute :role

--- a/lib/fog/brightbox/models/compute/volume.rb
+++ b/lib/fog/brightbox/models/compute/volume.rb
@@ -20,11 +20,12 @@ module Fog
         attribute :source_type
         attribute :storage_type
 
+        # Boolean flags
         attribute :boot
         attribute :delete_with_server
         attribute :encrypted
 
-        # Times
+        # Timestamps
         attribute :created_at, type: :time
         attribute :updated_at, type: :time
         attribute :deleted_at, type: :time

--- a/lib/fog/brightbox/models/compute/volume.rb
+++ b/lib/fog/brightbox/models/compute/volume.rb
@@ -9,7 +9,7 @@ module Fog
         attribute :url
 
         attribute :name
-        attribute :state, :aliases => "status"
+        attribute :state, aliases: "status"
 
         attribute :description
         attribute :filesystem_label
@@ -25,14 +25,14 @@ module Fog
         attribute :encrypted
 
         # Times
-        attribute :created_at, :type => :time
-        attribute :updated_at, :type => :time
-        attribute :deleted_at, :type => :time
+        attribute :created_at, type: :time
+        attribute :updated_at, type: :time
+        attribute :deleted_at, type: :time
 
         # Links
-        attribute :account_id, :aliases => "account", :squash => "id"
-        attribute :image_id, :aliases => "image", :squash => "id"
-        attribute :server_id, :aliases => "server", :squash => "id"
+        attribute :account_id, aliases: "account", squash: "id"
+        attribute :image_id, aliases: "image", squash: "id"
+        attribute :server_id, aliases: "server", squash: "id"
 
         def attach(server)
           requires :identity

--- a/lib/fog/brightbox/models/compute/volume.rb
+++ b/lib/fog/brightbox/models/compute/volume.rb
@@ -10,20 +10,20 @@ module Fog
 
         attribute :name
         attribute :state, aliases: "status"
-
         attribute :description
+
         attribute :filesystem_label
         attribute :filesystem_type
         attribute :serial
-        attribute :size
+        attribute :size, type: :integer
         attribute :source
         attribute :source_type
         attribute :storage_type
 
         # Boolean flags
-        attribute :boot
-        attribute :delete_with_server
-        attribute :encrypted
+        attribute :boot, type: :boolean
+        attribute :delete_with_server, type: :boolean
+        attribute :encrypted, type: :boolean
 
         # Timestamps
         attribute :created_at, type: :time

--- a/lib/fog/brightbox/models/compute/volume.rb
+++ b/lib/fog/brightbox/models/compute/volume.rb
@@ -5,8 +5,8 @@ module Fog
         include Fog::Brightbox::Compute::ResourceLocking
 
         identity :id
-        attribute :url
         attribute :resource_type
+        attribute :url
 
         attribute :name
         attribute :state, :aliases => "status"

--- a/lib/fog/brightbox/models/compute/zone.rb
+++ b/lib/fog/brightbox/models/compute/zone.rb
@@ -3,8 +3,8 @@ module Fog
     class Compute
       class Zone < Fog::Brightbox::Model
         identity :id
-        attribute :url
         attribute :resource_type
+        attribute :url
 
         attribute :status
         attribute :handle

--- a/lib/fog/brightbox/models/compute/zone.rb
+++ b/lib/fog/brightbox/models/compute/zone.rb
@@ -6,10 +6,9 @@ module Fog
         attribute :resource_type
         attribute :url
 
-        attribute :status
-        attribute :handle
-
         attribute :description
+        attribute :handle
+        attribute :status
       end
     end
   end


### PR DESCRIPTION

A number of attributes have been added upstream in the Brightbox
Infrastructure REST API. Some of these have been omitted from the
models.

This attempts to add the missing attributes so they can be accessed by
clients.

See: https://api.gb1.brightbox.com/1.0/