### PR TITLE
Implement `..Storage::Directory#public_url`

### DIFF
--- a/lib/fog/brightbox/models/storage/directory.rb
+++ b/lib/fog/brightbox/models/storage/directory.rb
@@ -31,8 +31,8 @@ module Fog
         attr_writer :public
 
         def public_url
-          # raise NotImplementedError
-          ""
+          requires :key
+          @public_url ||= [service.management_url , Fog::Brightbox::Storage.escape(key, "/")].join("/")
         end
 
         def save


### PR DESCRIPTION
This was not implemented in the OpenStack code we used as the template
for the storage server (OpenStack compatible) when we set up the code.

As such, attempting to generate a `File#public_url` would fail as it
relied on the directory URL being generated as well. The generated
string was only the object name.

Now it is correctly, the full URL (String) to access an object (if
public permissions are set).