### PR TITLE
Fix `Storage.escape` regexp

### DIFF
--- a/lib/fog/brightbox/storage.rb
+++ b/lib/fog/brightbox/storage.rb
@@ -215,7 +215,8 @@ module Fog
 
       # CGI.escape, but without special treatment on spaces
       def self.escape(str, extra_exclude_chars = "")
-        str.gsub(/([^a-zA-Z0-9_.-#{extra_exclude_chars}]+)/) do
+        # Includes fix to Regexp so "-" is correctly handled by placing last
+        str.gsub(/([^a-zA-Z0-9_.#{extra_exclude_chars}-]+)/) do
           "%" + Regexp.last_match[1].unpack("H2" * Regexp.last_match[1].bytesize).join("%").upcase
         end
       end


### PR DESCRIPTION
Several fixes arrived after we forked the original OpenStack code
including a fix to the `Storage.escape` method in the way it handled
dashes "-".

The dash was in the wrong place and treated differently by the regexp
resulting in dashes being replaced incorrectly in the URLs.