### PR TITLE
Deduplicate forward slashing in Storage URLs

### DIFF
--- a/lib/fog/brightbox/models/storage/directory.rb
+++ b/lib/fog/brightbox/models/storage/directory.rb
@@ -32,7 +32,8 @@ module Fog
 
         def public_url
           requires :key
-          @public_url ||= [service.management_url , Fog::Brightbox::Storage.escape(key, "/")].join("/")
+          @public_url ||= ::File.join(service.management_url.to_s,
+                                      Fog::Brightbox::Storage.escape(key, "/"))
         end
 
         def save

--- a/lib/fog/brightbox/models/storage/files.rb
+++ b/lib/fog/brightbox/models/storage/files.rb
@@ -63,9 +63,9 @@ module Fog
 
         def get_url(key)
           requires :directory
-          if directory.public_url
-            "#{directory.public_url}/#{Fog::Brightbox::Storage.escape(key, "/")}"
-          end
+          return unless directory.public_url
+
+          ::File.join(directory.public_url, Fog::Brightbox::Storage.escape(key, "/"))
         end
 
         def get_http_url(key, expires, options = {})

--- a/spec/fog/brightbox/storage/escape_spec.rb
+++ b/spec/fog/brightbox/storage/escape_spec.rb
@@ -1,0 +1,62 @@
+require "minitest/autorun"
+require "fog/brightbox"
+
+describe Fog::Brightbox::Storage, ".escape" do
+  describe "when only excluded characters are used" do
+    it "escapes no letters" do
+      str = ("A".."Z").to_a.join
+      escaped = Fog::Brightbox::Storage.escape(str)
+      assert_equal str, escaped
+
+      str = ("a".."z").to_a.join
+      escaped = Fog::Brightbox::Storage.escape(str)
+      assert_equal str, escaped
+    end
+
+    it "escapes no numbers" do
+      str = ("0".."9").to_a.join
+      escaped = Fog::Brightbox::Storage.escape(str)
+      assert_equal str, escaped
+    end
+
+    it "does not escape dashes" do
+      str = "test-pattern123"
+      escaped = Fog::Brightbox::Storage.escape(str)
+      assert_equal str, escaped
+    end
+
+    it "does not escape dots" do
+      str = "sample.demo"
+      escaped = Fog::Brightbox::Storage.escape(str)
+      assert_equal str, escaped
+    end
+
+    it "does not escape underscores" do
+      str = "file_name"
+      escaped = Fog::Brightbox::Storage.escape(str)
+      assert_equal str, escaped
+    end
+  end
+
+  describe "when escaped characters are included" do
+    it "escapes those forward slashes" do
+      str = "test/pattern/123.txt"
+      escaped = Fog::Brightbox::Storage.escape(str)
+      assert_equal "test%2Fpattern%2F123.txt", escaped
+    end
+
+    it "escapes those backslashes" do
+      str = "test\\pattern\\123.txt"
+      escaped = Fog::Brightbox::Storage.escape(str)
+      assert_equal "test%5Cpattern%5C123.txt", escaped
+    end
+  end
+
+  describe "when additional characters are excluded" do
+    it "escapes those characters" do
+      str = "test/pattern/123.txt"
+      escaped = Fog::Brightbox::Storage.escape(str, "/")
+      assert_equal "test/pattern/123.txt", escaped
+    end
+  end
+end

--- a/spec/fog/brightbox/storage/files_spec.rb
+++ b/spec/fog/brightbox/storage/files_spec.rb
@@ -1,0 +1,88 @@
+require "minitest/autorun"
+require "fog/brightbox"
+require "fog/brightbox/models/storage/directory"
+require "fog/brightbox/models/storage/files"
+
+describe Fog::Brightbox::Storage::Files do
+  describe "#get_url" do
+    before do
+      @options = {
+        :brightbox_client_id => "cli-12345",
+        :brightbox_secret => "1234567890",
+        :brightbox_storage_management_url => "https://management.url/v1/acc-12345"
+      }
+      @service = Fog::Brightbox::Storage.new(@options)
+    end
+
+    describe "when directory can generate URL" do
+      describe "with object prefixed by forward slash" do
+        it do
+          assert_equal "https://management.url/v1/acc-12345", @service.management_url.to_s
+
+          directory = Fog::Brightbox::Storage::Directory.new(
+            service: @service,
+            key: "container-name"
+          )
+          assert_equal "https://management.url/v1/acc-12345/container-name", directory.public_url
+
+          files = Fog::Brightbox::Storage::Files.new(
+            service: @service,
+            directory: directory
+          )
+
+          expected = "https://management.url/v1/acc-12345/container-name/object"
+
+          assert_equal expected, files.get_url("/object")
+        end
+      end
+
+      describe "when object is correctly named" do
+        it do
+          assert_equal "https://management.url/v1/acc-12345", @service.management_url.to_s
+
+          directory = Fog::Brightbox::Storage::Directory.new(
+            service: @service,
+            key: "container-name"
+          )
+          assert_equal "https://management.url/v1/acc-12345/container-name", directory.public_url
+
+          files = Fog::Brightbox::Storage::Files.new(
+            service: @service,
+            directory: directory
+          )
+
+          expected = "https://management.url/v1/acc-12345/container-name/object"
+
+          assert_equal expected, files.get_url("object")
+        end
+      end
+    end
+
+    describe "when no management URL" do
+      before do
+        @options = {
+          :brightbox_client_id => "cli-12345",
+          :brightbox_secret => "1234567890"
+        }
+        @service = Fog::Brightbox::Storage.new(@options)
+      end
+
+      it do
+        assert_equal "", @service.management_url.to_s
+
+        directory = Fog::Brightbox::Storage::Directory.new(
+          service: @service,
+          key: "container-name"
+        )
+        assert_equal "/container-name", directory.public_url
+
+        files = Fog::Brightbox::Storage::Files.new(
+          service: @service,
+          directory: directory
+        )
+
+        assert_equal "/container-name/object", files.get_url("/object")
+      end
+    end
+  end
+end

--- a/spec/fog/brightbox/storage_spec.rb
+++ b/spec/fog/brightbox/storage_spec.rb
@@ -1,0 +1,34 @@
+require "minitest/autorun"
+require "fog/brightbox"
+
+describe Fog::Brightbox::Storage do
+  describe "when passed in configuration" do
+    before do
+      @options = {
+        :brightbox_client_id => "cli-12345",
+        :brightbox_secret => "1234567890",
+        :brightbox_storage_management_url => "https://management.url/v1/acc-12345"
+      }
+      @service = Fog::Brightbox::Storage.new(@options)
+    end
+
+    it "returns a URI matching config option" do
+      assert_kind_of URI, @service.management_url
+      assert_equal "https://management.url/v1/acc-12345", @service.management_url.to_s
+    end
+  end
+
+  describe "when unavailable" do
+    before do
+      @options = {
+        :brightbox_client_id => "cli-12345",
+        :brightbox_secret => "1234567890"
+      }
+      @service = Fog::Brightbox::Storage.new(@options)
+    end
+
+    it "returns nil" do
+      assert_nil @service.management_url
+    end
+  end
+end


### PR DESCRIPTION
This uses `File.join` to assemble URLs such that storage objects named
with a forward slash prefix do not result in double slashes.

We also add specs covering some of the behaviour to catch any other odd
cases and prevent regressions.