### PR TITLE
Allow custom volume size in server creation

### DIFF
--- a/lib/fog/brightbox/models/compute/server.rb
+++ b/lib/fog/brightbox/models/compute/server.rb
@@ -8,6 +8,7 @@ module Fog
         include Fog::Brightbox::Compute::ResourceLocking
 
         attr_accessor :volume_id
+        attr_accessor :volume_size
 
         identity :id
         attribute :resource_type
@@ -197,7 +198,16 @@ module Fog
           options.merge!(:disk_encrypted => disk_encrypted) if disk_encrypted
 
           if volume_id
-            options.merge!(:volumes => [:volume => volume_id])
+            options.merge!(:volumes => [{ volume: volume_id }])
+          elsif volume_size
+            options.merge!(
+              volumes: [
+                {
+                  image: image_id,
+                  size: volume_size
+                }
+              ]
+            )
           else
             options.merge!(:image => image_id)
           end

--- a/spec/fog/compute/brightbox/server_spec.rb
+++ b/spec/fog/compute/brightbox/server_spec.rb
@@ -20,7 +20,7 @@ describe Fog::Brightbox::Compute::Server do
   end
 
   describe "when creating" do
-    describe "with required image_id" do
+    describe "with image_id" do
       it "sends correct JSON" do
         options = {
           image_id: "img-12345"
@@ -31,6 +31,33 @@ describe Fog::Brightbox::Compute::Server do
                :headers => { "Authorization" => "Bearer FAKECACHEDTOKEN",
                              "Content-Type" => "application/json" },
                              :body => hash_including(:image => "img-12345")).
+        to_return(:status => 202, :body => %q({"id":"srv-12345"}), :headers => {})
+
+        @server = Fog::Brightbox::Compute::Server.new({ :service => service }.merge(options))
+        assert @server.save
+      end
+    end
+
+    describe "with image_id and custom size" do
+      it "sends correct JSON" do
+        options = {
+          image_id: "img-12345",
+          volume_size: 25_000
+        }
+        expected_args = {
+          volumes: [
+            {
+              image: "img-12345",
+              size: 25_000
+            }
+          ]
+        }
+
+        stub_request(:post, "http://localhost/1.0/servers").
+          with(:query => hash_including(:account_id),
+               :headers => { "Authorization" => "Bearer FAKECACHEDTOKEN",
+                             "Content-Type" => "application/json" },
+                             :body => hash_including(expected_args)).
         to_return(:status => 202, :body => %q({"id":"srv-12345"}), :headers => {})
 
         @server = Fog::Brightbox::Compute::Server.new({ :service => service }.merge(options))
@@ -58,6 +85,27 @@ describe Fog::Brightbox::Compute::Server do
         assert @server.save
         assert @server.disk_encrypted
       end
+    end
+  end
+
+  describe "with volume_id" do
+    it "sends correct JSON" do
+      options = {
+        volume_id: "vol-12345"
+      }
+      expected_args = {
+        volumes: [{ volume: "vol-12345" }]
+      }
+
+      stub_request(:post, "http://localhost/1.0/servers").
+        with(:query => hash_including(:account_id),
+             :headers => { "Authorization" => "Bearer FAKECACHEDTOKEN",
+                           "Content-Type" => "application/json" },
+                           :body => hash_including(expected_args)).
+      to_return(:status => 202, :body => %q({"id":"srv-12345"}), :headers => {})
+
+      @server = Fog::Brightbox::Compute::Server.new({ :service => service }.merge(options))
+      assert @server.save
     end
   end
 


### PR DESCRIPTION
There is now an extended volumes API which allows passing a custom
volume size to network based storage. Along with attaching existing
volumes, that gives three variants that need to be passed through when
called with specific arguments.

Argument logic is not enforced here but left up to the API so mututally
exclusive arguments may be sent.