### PR TITLE
Update model arguments for new image API

### DIFF
--- a/lib/fog/brightbox/models/compute/image.rb
+++ b/lib/fog/brightbox/models/compute/image.rb
@@ -14,13 +14,16 @@ module Fog
 
         attribute :arch
         attribute :disk_size, type: :integer
+        attribute :http_url
         attribute :licence_name
         attribute :min_ram, type: :integer
+        attribute :server
         attribute :source
         attribute :source_trigger
         attribute :source_type
         attribute :username
         attribute :virtual_size, type: :integer
+        attribute :volume
 
         # Boolean flags
         attribute :compatibility_mode, type: :boolean
@@ -40,13 +43,16 @@ module Fog
 
         def save
           raise Fog::Errors::Error.new("Resaving an existing object may create a duplicate") if persisted?
-          requires :source, :arch
+
           options = {
-            :source => source,
             :arch => arch,
+            :description => description,
+            :http_url => http_url,
             :name => name,
+            :server => server,
+            :source => source,
             :username => username,
-            :description => description
+            :volume => volume
           }.delete_if { |_k, v| v.nil? || v == "" }
           data = service.create_image(options)
           merge_attributes(data)


### PR DESCRIPTION
The API has been expanded such that the following options are available for registration:

* `arch` and `source` for FTP uploaded images
* `arch` and `http_url` for pulling image from a HTTP server
* `server` to create a snapshot using a server ID
* `volume` to create a using a volume ID

As such the existing "requires" filter would prevent usage of the models in these other cases.