### PR TITLE
Switch to use `setup-ruby@v1` for Github actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,8 +26,7 @@ jobs:
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
The SHA release previously in use is missing bugfixes and the latest tests failed due to some Ruby/Bundler version conflict in the test runners.

Testing to see if the issues occur with the latest version