### PR TITLE
Add missing `encrypted` parameter to `Volume#save`

### DIFF
--- a/lib/fog/brightbox/models/compute/volume.rb
+++ b/lib/fog/brightbox/models/compute/volume.rb
@@ -126,6 +126,7 @@ module Fog
             options = {
               :delete_with_server => delete_with_server,
               :description => description,
+              :encrypted => encrypted,
               :filesystem_label => filesystem_label,
               :filesystem_type => filesystem_type,
               :name => name,


### PR DESCRIPTION
Since parameters are filtered in the models, the missing `encrypted` parameters results in the API never receiving a flag passed in to the model when `#save` is called.

This adds it to the allowed list.