### PR TITLE
bump maximum allowed rubocop version

### DIFF
--- a/fog-brightbox.gemspec
+++ b/fog-brightbox.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rubocop", "< 0.50"
+  spec.add_development_dependency "rubocop", "< 1.40"
   spec.add_development_dependency "shindo"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "yard"


### PR DESCRIPTION
I picked this arbitrary version simply because I have 1.39 installed, I think it can be just safe to bump this to `"< 2.0"`.
Version 0.50 was released in 2017.

Here bundle exec rake on my system:
```
rake test
/home/micwoj92/pkg/fog-brightbox/lib/fog/brightbox/models/compute/flavor.rb:20: warning: method redefined; discarding old bits
/usr/lib/ruby/gems/3.0.0/gems/fog-core-2.3.0/lib/fog/core/attributes/default.rb:52: warning: previous definition of bits was here
/usr/lib/ruby/gems/3.0.0/gems/fog-core-2.3.0/lib/fog/core/attributes/default.rb:43: warning: method redefined; discarding old nodes=
/usr/lib/ruby/gems/3.0.0/gems/fog-core-2.3.0/lib/fog/core/attributes/default.rb:43: warning: previous definition of nodes= was here
/usr/lib/ruby/gems/3.0.0/gems/fog-core-2.3.0/lib/fog/core/attributes/default.rb:52: warning: method redefined; discarding old nodes
/usr/lib/ruby/gems/3.0.0/gems/fog-core-2.3.0/lib/fog/core/attributes/default.rb:52: warning: previous definition of nodes was here
/home/micwoj92/pkg/fog-brightbox/lib/fog/brightbox/models/compute/load_balancer.rb:82: warning: method redefined; discarding old certificate_expires_at
/usr/lib/ruby/gems/3.0.0/gems/fog-core-2.3.0/lib/fog/core/attributes/default.rb:52: warning: previous definition of certificate_expires_at was here
/home/micwoj92/pkg/fog-brightbox/lib/fog/brightbox/models/compute/load_balancer.rb:87: warning: method redefined; discarding old certificate_subject
/usr/lib/ruby/gems/3.0.0/gems/fog-core-2.3.0/lib/fog/core/attributes/default.rb:52: warning: previous definition of certificate_subject was here
Run options: --seed 17974

# Running:

......................................................................................................................................................................................................................................................................

Finished in 0.269072s, 973.7182 runs/s, 1397.3972 assertions/s.

262 runs, 376 assertions, 0 failures, 0 errors, 0 skips
```