### PR TITLE
Test older Ruby versions using Ubuntu 20.04 LTS

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,17 +15,32 @@ on:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "head"]
-
+        ruby-version: ["2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "head"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: bundle exec rake
+
+  test-old:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        ruby-version: ["2.1", "2.2", "2.3"]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+      # change this to (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}


### PR DESCRIPTION
The GitHub `setup-ruby` code seems to have hit technical limits preventing Ruby 2.2 and older from working on the available action runners.

Beyond dropping support, apparently using Ubuntu 20.04 LTS for testing is apparently a working solution.