### PR TITLE
Remove `rubocop` dependency version

### DIFF
--- a/fog-brightbox.gemspec
+++ b/fog-brightbox.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rubocop", "< 0.50"
+  spec.add_development_dependency "rubocop"
   spec.add_development_dependency "shindo"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "yard"


### PR DESCRIPTION
Since this is a development dependency, finding a correct version to work among Ruby, Bundler and OS should probably be left as an exercise to the developer.