### PR TITLE
Conditionally add `base64` gem requirement

### DIFF
--- a/fog-brightbox.gemspec
+++ b/fog-brightbox.gemspec
@@ -22,7 +22,10 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.0"
 
-  spec.add_dependency "base64"
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4")
+    spec.add_dependency "base64"
+  end
+
   spec.add_dependency "fog-core", ">= 1.45", "< 3.0"
   spec.add_dependency "fog-json"
   spec.add_dependency "dry-inflector"


### PR DESCRIPTION
Ruby 2.1 and 2.2 are unable to use the `base64` gem due to version constraints on the gem. Ruby 3.4 requires that gem as `Base64` has been removed from the standard library.

This adds a condition around the dependency so only Ruby 3.4 requires the gem to restore the standard library behaviour.