### PR TITLE
Setup `simplecov` as developer dependency

### DIFF
--- a/fog-brightbox.gemspec
+++ b/fog-brightbox.gemspec
@@ -36,6 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "shindo"
+  spec.add_development_dependency "simplecov"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "yard"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,14 @@
+require "simplecov"
+
+SimpleCov.start do
+  add_filter "/spec/"
+  add_filter "/config/"
+  add_filter "/vendor/"
+end
+
+# Currently just above 75% coverage - don't make it worse
+SimpleCov.minimum_coverage 75
+
 require "minitest/autorun"
 require "fog/brightbox"
 require "model_setup"


### PR DESCRIPTION
Sets a 75% coverage threshold to prevent things getting worse than the current 76%