### PR TITLE
Update DBS test for new API behaviour

### DIFF
--- a/tests/brightbox/models/compute/database_server_tests.rb
+++ b/tests/brightbox/models/compute/database_server_tests.rb
@@ -48,8 +48,8 @@ Shindo.tests("Fog::Compute[:brightbox] | DatabaseServer model", ["brightbox"]) d
         !@database_server.admin_username.nil?
       end
 
-      test("admin_password is nil") do
-        @database_server.admin_password.nil?
+      test("admin_password is not nil") do
+        !@database_server.admin_password.nil?
       end
     end
 


### PR DESCRIPTION
Previously the API would only return the admin password during creation as it was transient. This has been revised and is now stored encrypted and is returned in other API requests such as a GET request.

The test is therefore incorrectly reporting errors against the new behaviour and needed updating.